### PR TITLE
Global refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ target/
 
 # Mac stuff
 .DS_Store
+
+# Eclipse
+.settings/

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ target/
 
 # Eclipse
 .settings/
+
+# IntelliJ
+.idea/

--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ UAVCAN is a lightweight protocol designed for reliable communication in aerospac
 
 ## Installation
 
-This library is dependency-free. Compatible Python versions are 2.7 and 3.3 and newer.
+Compatible Python versions are 2.7 and 3.3 and newer.
+If the library is used with Python 3, which is recommended, it does not require any additional dependencies.
+If Python 2.7 is used, additional dependencies are needed - refer to `setup.py` for more info.
 
 ```bash
 pip install uavcan
@@ -22,4 +24,5 @@ pip install uavcan
 
 ## Development
 
-The code should be formatted in compliance with [PEP8](https://www.python.org/dev/peps/pep-0008/).
+The code should be formatted in compliance with [PEP8](https://www.python.org/dev/peps/pep-0008/),
+with one exception: line length must not exceed 120 characters (PEP8 requires 79).

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import os
+import sys
 from setuptools import setup
 
 args = dict(
@@ -26,6 +27,9 @@ args = dict(
     ],
     keywords=''
 )
+
+if sys.version_info[0] < 3:
+    args['install_requires'] = ['monotonic']
 
 setup(**args)
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,12 @@
 #!/usr/bin/env python
+#
+# Copyright (C) 2014-2015  UAVCAN Development Team  <uavcan.org>
+#
+# This software is distributed under the terms of the MIT License.
+#
+# Author: Ben Dyer <ben_dyer@mac.com>
+#         Pavel Kirienko <pavel.kirienko@zubax.com>
+#
 
 import os
 import sys
@@ -32,4 +40,3 @@ if sys.version_info[0] < 3:
     args['install_requires'] = ['monotonic']
 
 setup(**args)
-

--- a/test/dsdl/test_common.py
+++ b/test/dsdl/test_common.py
@@ -1,3 +1,12 @@
+#
+# Copyright (C) 2014-2015  UAVCAN Development Team  <uavcan.org>
+#
+# This software is distributed under the terms of the MIT License.
+#
+# Author: Ben Dyer <ben_dyer@mac.com>
+#         Pavel Kirienko <pavel.kirienko@zubax.com>
+#
+
 import os
 import unittest
 from uavcan.dsdl import common

--- a/test/dsdl/test_parser.py
+++ b/test/dsdl/test_parser.py
@@ -1,3 +1,12 @@
+#
+# Copyright (C) 2014-2015  UAVCAN Development Team  <uavcan.org>
+#
+# This software is distributed under the terms of the MIT License.
+#
+# Author: Ben Dyer <ben_dyer@mac.com>
+#         Pavel Kirienko <pavel.kirienko@zubax.com>
+#
+
 import unittest
 from uavcan.dsdl import parser
 

--- a/test/dsdl/test_signature.py
+++ b/test/dsdl/test_signature.py
@@ -1,3 +1,12 @@
+#
+# Copyright (C) 2014-2015  UAVCAN Development Team  <uavcan.org>
+#
+# This software is distributed under the terms of the MIT License.
+#
+# Author: Ben Dyer <ben_dyer@mac.com>
+#         Pavel Kirienko <pavel.kirienko@zubax.com>
+#
+
 import unittest
 from uavcan.dsdl import signature
 

--- a/test/test_driver.py
+++ b/test/test_driver.py
@@ -1,3 +1,12 @@
+#
+# Copyright (C) 2014-2015  UAVCAN Development Team  <uavcan.org>
+#
+# This software is distributed under the terms of the MIT License.
+#
+# Author: Ben Dyer <ben_dyer@mac.com>
+#         Pavel Kirienko <pavel.kirienko@zubax.com>
+#
+
 import unittest
 from uavcan import driver
 

--- a/test/test_node.py
+++ b/test/test_node.py
@@ -1,3 +1,12 @@
+#
+# Copyright (C) 2014-2015  UAVCAN Development Team  <uavcan.org>
+#
+# This software is distributed under the terms of the MIT License.
+#
+# Author: Ben Dyer <ben_dyer@mac.com>
+#         Pavel Kirienko <pavel.kirienko@zubax.com>
+#
+
 import unittest
 from uavcan import node
 

--- a/test/test_transport.py
+++ b/test/test_transport.py
@@ -103,22 +103,22 @@ class TestBEFromLEBits(unittest.TestCase):
         #                                     llllllllmmmm
         out_bits = transport.be_from_le_bits("110110101110", 12)
         #                                     mmmmllllllll
-        self.assertEqual(out_bits,           "111011011010")
+        self.assertEqual(out_bits, "111011011010")
 
         #                                     llllllllmmmmmmmm
         out_bits = transport.be_from_le_bits("1010010110010110", 16)
         #                                     mmmmmmmmllllllll
-        self.assertEqual(out_bits,           "1001011010100101")
+        self.assertEqual(out_bits, "1001011010100101")
 
         #                                     llllllll........m
         out_bits = transport.be_from_le_bits("11010010110010110", 17)
         #                                     m........llllllll
-        self.assertEqual(out_bits,           "01100101111010010")
+        self.assertEqual(out_bits, "01100101111010010")
 
         #                                     llllllll........m
         out_bits = transport.be_from_le_bits("10100101100101101", 17)
         #                                     m........llllllll
-        self.assertEqual(out_bits,           "11001011010100101")
+        self.assertEqual(out_bits, "11001011010100101")
 
 
 class TestLEFromBEBits(unittest.TestCase):
@@ -137,22 +137,22 @@ class TestLEFromBEBits(unittest.TestCase):
         #                                     mmmmllllllll
         out_bits = transport.le_from_be_bits("111011011010", 12)
         #                                     llllllllmmmm
-        self.assertEqual(out_bits,           "110110101110")
+        self.assertEqual(out_bits, "110110101110")
 
         #                                     mmmmmmmmllllllll
         out_bits = transport.le_from_be_bits("1001011010100101", 16)
         #                                     llllllllmmmmmmmm
-        self.assertEqual(out_bits,           "1010010110010110")
+        self.assertEqual(out_bits, "1010010110010110")
 
         #                                     m........llllllll
         out_bits = transport.le_from_be_bits("01100101111010010", 17)
         #                                     llllllll........m
-        self.assertEqual(out_bits,           "11010010110010110")
+        self.assertEqual(out_bits, "11010010110010110")
 
         #                                     m........llllllll
         out_bits = transport.le_from_be_bits("11001011010100101", 17)
         #                                     llllllll........m
-        self.assertEqual(out_bits,           "10100101100101101")
+        self.assertEqual(out_bits, "10100101100101101")
 
 
 class TestCast(unittest.TestCase):
@@ -382,8 +382,9 @@ class TestArrayBasic(unittest.TestCase):
                 "c"
             )
         ]
+
         def custom_type_factory(*args, **kwargs):
-            return transport.CompoundValue(custom_type, tao=True, *args, **kwargs)
+            return transport.CompoundValue(custom_type, _tao=True, *args, **kwargs)
         custom_type._instantiate = custom_type_factory
 
         self.a1_type = parser.ArrayType(
@@ -417,9 +418,9 @@ class TestArrayBasic(unittest.TestCase):
         self.assertEqual(self.a3_type.get_max_bitlen(), (8 + 16 + 5 + 3) * 2)
 
     def test_representation(self):
-        a1 = transport.ArrayValue(self.a1_type, tao=False)
-        a2 = transport.ArrayValue(self.a2_type, tao=False)
-        a3 = transport.ArrayValue(self.a3_type, tao=True)
+        a1 = transport.ArrayValue(self.a1_type, _tao=False)
+        a2 = transport.ArrayValue(self.a2_type, _tao=False)
+        a3 = transport.ArrayValue(self.a3_type, _tao=True)
         for i in range(4):
             a1[i] = i
         for i in range(2):
@@ -474,8 +475,9 @@ class TestVoid(unittest.TestCase):
                 "b"
             )
         ]
+
         def custom_type_factory(*args, **kwargs):
-            return transport.CompoundValue(self.custom_type, tao=True, *args,
+            return transport.CompoundValue(self.custom_type, _tao=True, *args,
                                            **kwargs)
         self.custom_type._instantiate = custom_type_factory
 
@@ -530,8 +532,9 @@ class TestMessageUnion(unittest.TestCase):
                 "b"
             )
         ]
+
         def custom_type_factory(*args, **kwargs):
-            return transport.CompoundValue(self.custom_type, tao=True, *args,
+            return transport.CompoundValue(self.custom_type, _tao=True, *args,
                                            **kwargs)
         self.custom_type._instantiate = custom_type_factory
 

--- a/test/test_transport.py
+++ b/test/test_transport.py
@@ -1,3 +1,12 @@
+#
+# Copyright (C) 2014-2015  UAVCAN Development Team  <uavcan.org>
+#
+# This software is distributed under the terms of the MIT License.
+#
+# Author: Ben Dyer <ben_dyer@mac.com>
+#         Pavel Kirienko <pavel.kirienko@zubax.com>
+#
+
 import unittest
 from uavcan import transport
 from uavcan.dsdl import parser

--- a/uavcan/__init__.py
+++ b/uavcan/__init__.py
@@ -7,6 +7,7 @@ Python UAVCAN package.
 Supported Python versions: 3.2+, 2.7.
 '''
 
+from __future__ import division, absolute_import, print_function, unicode_literals
 import os
 import sys
 import struct

--- a/uavcan/__init__.py
+++ b/uavcan/__init__.py
@@ -21,6 +21,11 @@ except AttributeError:
     import monotonic                        # 3rd party dependency for old versions
     time.monotonic = monotonic.monotonic
 
+
+class UAVCANException(Exception):
+    pass
+
+
 import uavcan.node as node
 from uavcan.node import make_node
 import uavcan.dsdl as dsdl

--- a/uavcan/__init__.py
+++ b/uavcan/__init__.py
@@ -41,6 +41,10 @@ import uavcan.dsdl as dsdl
 import uavcan.transport as transport
 
 
+TRANSFER_PRIORITY_LOWEST = 31
+TRANSFER_PRIORITY_HIGHEST = 0
+
+
 logger = getLogger(__name__)
 
 

--- a/uavcan/__init__.py
+++ b/uavcan/__init__.py
@@ -11,8 +11,17 @@ import os
 import sys
 import struct
 import logging
-import functools
 import pkg_resources
+import time
+
+try:
+    time.monotonic                          # Works natively in Python 3.3+
+except AttributeError:
+    import monotonic                        # 3rd party dependency for old versions
+    time.monotonic = monotonic.monotonic
+
+import uavcan.node as node
+from uavcan.node import make_node
 import uavcan.dsdl as dsdl
 import uavcan.transport as transport
 
@@ -68,14 +77,13 @@ def load_dsdl(*paths, **args):
     # Try to prepend the built-in DSDL files
     try:
         if not args.get("exclude_dist", None):
-            dsdl_path = pkg_resources.resource_filename(__name__,
-                                                        "dsdl_files")
+            dsdl_path = pkg_resources.resource_filename(__name__, "dsdl_files")
             paths = [os.path.join(dsdl_path, "uavcan")] + paths
     except Exception:
         pass
 
     root_namespace = Namespace()
-    dtypes = dsdl.parse_namespaces(paths, [])
+    dtypes = dsdl.parse_namespaces(paths)
     for dtype in dtypes:
         namespace, _, typename = dtype.full_name.rpartition(".")
         root_namespace._path(namespace).__dict__[typename] = dtype
@@ -84,16 +92,13 @@ def load_dsdl(*paths, **args):
         if dtype.default_dtid:
             DATATYPES[(dtype.default_dtid, dtype.kind)] = dtype
             # Add the base CRC to each data type capable of being transmitted
-            dtype.base_crc = dsdl.common.crc16_from_bytes(
-                struct.pack("<Q", dtype.get_data_type_signature()))
-            logging.debug("DSDL Load {: >30} DTID: {: >4} base_crc:{: >8}".
-                          format(typename, dtype.default_dtid,
-                                 hex(dtype.base_crc)))
+            dtype.base_crc = dsdl.common.crc16_from_bytes(struct.pack("<Q", dtype.get_data_type_signature()))
+            logging.debug("DSDL Load {: >30} DTID: {: >4} base_crc:{: >8}"
+                          .format(typename, dtype.default_dtid, hex(dtype.base_crc)))
 
         def create_instance_closure(closure_type):
             def create_instance(*args, **kwargs):
-                return transport.CompoundValue(closure_type, tao=True, *args,
-                                               **kwargs)
+                return transport.CompoundValue(closure_type, tao=True, *args, **kwargs)
             return create_instance
 
         dtype._instantiate = create_instance_closure(dtype)
@@ -105,8 +110,7 @@ def load_dsdl(*paths, **args):
     MODULE.__dict__["thirdparty"] = Namespace()
     for ext_namespace in root_namespace._namespaces():
         if str(ext_namespace) != "uavcan":
-            MODULE.thirdparty.__dict__[str(ext_namespace)] = \
-                root_namespace.__dict__[ext_namespace]
+            MODULE.thirdparty.__dict__[str(ext_namespace)] = root_namespace.__dict__[ext_namespace]
 
 
 __all__ = ["dsdl", "transport", "load_dsdl", "DATATYPES", "TYPENAMES"]
@@ -119,3 +123,7 @@ MODULE.__dict__ = globals()
 MODULE._module = sys.modules[MODULE.__name__]
 MODULE._pmodule = MODULE
 sys.modules[MODULE.__name__] = MODULE
+
+
+# Completing package initialization with loading default DSDL definitions
+load_dsdl()

--- a/uavcan/__init__.py
+++ b/uavcan/__init__.py
@@ -18,8 +18,17 @@ from logging import getLogger
 try:
     time.monotonic                          # Works natively in Python 3.3+
 except AttributeError:
-    import monotonic                        # 3rd party dependency for old versions @UnresolvedImport
-    time.monotonic = monotonic.monotonic
+    try:
+        import monotonic                    # 3rd party dependency for old versions @UnresolvedImport
+        time.monotonic = monotonic.monotonic
+    except ImportError:
+        time.monotonic = time.time          # Last resort - using non-monotonic time; this is no good but oh well
+        print('''The package 'monotonic' is not available, the library will use real time instead of monotonic time.
+This implies that the library may misbehave if system clock is adjusted while the library is running.
+In order to fix this problem, consider either option:
+ 1. Switch to Python 3.
+ 2. Install the missing package, e.g. using pip:
+    pip install monotonic''', file=sys.stderr)
 
 
 class UAVCANException(Exception):

--- a/uavcan/__init__.py
+++ b/uavcan/__init__.py
@@ -11,9 +11,9 @@ from __future__ import division, absolute_import, print_function, unicode_litera
 import os
 import sys
 import struct
-import logging
 import pkg_resources
 import time
+from logging import getLogger
 
 try:
     time.monotonic                          # Works natively in Python 3.3+
@@ -25,6 +25,9 @@ import uavcan.node as node
 from uavcan.node import make_node
 import uavcan.dsdl as dsdl
 import uavcan.transport as transport
+
+
+logger = getLogger(__name__)
 
 
 class Module(object):
@@ -94,8 +97,8 @@ def load_dsdl(*paths, **args):
             DATATYPES[(dtype.default_dtid, dtype.kind)] = dtype
             # Add the base CRC to each data type capable of being transmitted
             dtype.base_crc = dsdl.common.crc16_from_bytes(struct.pack("<Q", dtype.get_data_type_signature()))
-            logging.debug("DSDL Load {: >30} DTID: {: >4} base_crc:{: >8}"
-                          .format(typename, dtype.default_dtid, hex(dtype.base_crc)))
+            logger.debug("DSDL Load {: >30} DTID: {: >4} base_crc:{: >8}"
+                         .format(typename, dtype.default_dtid, hex(dtype.base_crc)))
 
         def create_instance_closure(closure_type):
             def create_instance(*args, **kwargs):

--- a/uavcan/__init__.py
+++ b/uavcan/__init__.py
@@ -18,7 +18,7 @@ from logging import getLogger
 try:
     time.monotonic                          # Works natively in Python 3.3+
 except AttributeError:
-    import monotonic                        # 3rd party dependency for old versions
+    import monotonic                        # 3rd party dependency for old versions @UnresolvedImport
     time.monotonic = monotonic.monotonic
 
 
@@ -86,7 +86,7 @@ def load_dsdl(*paths, **args):
     # Try to prepend the built-in DSDL files
     try:
         if not args.get("exclude_dist", None):
-            dsdl_path = pkg_resources.resource_filename(__name__, "dsdl_files")
+            dsdl_path = pkg_resources.resource_filename(__name__, "dsdl_files")  # @UndefinedVariable
             paths = [os.path.join(dsdl_path, "uavcan")] + paths
     except Exception:
         pass

--- a/uavcan/__init__.py
+++ b/uavcan/__init__.py
@@ -107,7 +107,7 @@ def load_dsdl(*paths, **args):
 
         def create_instance_closure(closure_type):
             def create_instance(*args, **kwargs):
-                return transport.CompoundValue(closure_type, tao=True, *args, **kwargs)
+                return transport.CompoundValue(closure_type, _tao=True, *args, **kwargs)
             return create_instance
 
         dtype._instantiate = create_instance_closure(dtype)

--- a/uavcan/__init__.py
+++ b/uavcan/__init__.py
@@ -1,5 +1,10 @@
 #
-# Copyright (C) 2014 Pavel Kirienko <pavel.kirienko@gmail.com>
+# Copyright (C) 2014-2015  UAVCAN Development Team  <uavcan.org>
+#
+# This software is distributed under the terms of the MIT License.
+#
+# Author: Ben Dyer <ben_dyer@mac.com>
+#         Pavel Kirienko <pavel.kirienko@zubax.com>
 #
 
 '''

--- a/uavcan/__init__.py
+++ b/uavcan/__init__.py
@@ -116,7 +116,7 @@ def load_dsdl(*paths, **args):
 
         def create_instance_closure(closure_type):
             def create_instance(*args, **kwargs):
-                return transport.CompoundValue(closure_type, _tao=True, *args, **kwargs)
+                return transport.CompoundValue(closure_type, *args, **kwargs)
             return create_instance
 
         dtype._instantiate = create_instance_closure(dtype)

--- a/uavcan/driver.py
+++ b/uavcan/driver.py
@@ -30,7 +30,7 @@ try:
     import serial
 except ImportError:
     serial = None
-    logger.info("uavcan.driver cannot import PySerial; SLCAN will not be available.")
+    logger.info("Cannot import PySerial; SLCAN will not be available.")
 
 
 class DriverError(uavcan.UAVCANException):
@@ -167,6 +167,11 @@ class RxFrame:
         self.ts_monotonic = ts_monotonic or time.monotonic()
         self.ts_real = ts_real or time.monotonic()
 
+    def __str__(self):
+        return '%0*x %s' % (8 if self.extended else 3, self.id, binascii.hexlify(self.data).decode())
+
+    __repr__ = __str__
+
 
 class SocketCAN(object):
     FRAME_FORMAT = '=IB3x8s'
@@ -258,7 +263,7 @@ class SLCAN(object):
 
     def _parse(self, message):
         try:
-            id_len = 8 if message[0] == b'T' else 3
+            id_len = 8 if message[0] == serial.to_bytes(b'T')[0] else 3
 
             # Parse the message into a (message ID, data) tuple.
             packet_id = int(message[1:1 + id_len].decode(), 16)

--- a/uavcan/driver.py
+++ b/uavcan/driver.py
@@ -1,4 +1,11 @@
-# encoding=utf-8
+#
+# Copyright (C) 2014-2015  UAVCAN Development Team  <uavcan.org>
+#
+# This software is distributed under the terms of the MIT License.
+#
+# Author: Ben Dyer <ben_dyer@mac.com>
+#         Pavel Kirienko <pavel.kirienko@zubax.com>
+#
 
 from __future__ import division, absolute_import, print_function, unicode_literals
 import os

--- a/uavcan/driver.py
+++ b/uavcan/driver.py
@@ -7,10 +7,11 @@ import time
 import fcntl
 import socket
 import struct
-import logging
 import binascii
 import select
+from logging import getLogger
 
+logger = getLogger(__name__)
 
 __all__ = ['make_driver']
 
@@ -20,8 +21,7 @@ try:
     import serial
 except ImportError:
     serial = None
-    logging.info("uavcan.driver cannot import PySerial; SLCAN will not be "
-                 "available.")
+    logger.info("uavcan.driver cannot import PySerial; SLCAN will not be available.")
 
 
 # Python 3.3+'s socket module has support for SocketCAN when running on Linux. Use that if possible.
@@ -156,7 +156,7 @@ class SocketCAN(object):
             return can_id & CAN_EFF_MASK, can_data[0:can_dlc], bool(can_id & CAN_EFF_FLAG)
 
     def send(self, message_id, message, extended=False):
-        logging.debug("CAN.send({!r}, {!r}, {!r})".format(message_id, binascii.hexlify(message), extended))
+        logger.debug("CAN.send({!r}, {!r}, {!r})".format(message_id, binascii.hexlify(message), extended))
 
         if extended:
             message_id |= CAN_EFF_FLAG
@@ -238,7 +238,7 @@ class SLCAN(object):
             # ID, data, extended
             return packet_id, packet_data, (id_len == 8)
         except Exception:
-            logging.error('Could not parse SLCAN frame [%r]', message, exc_info=True)
+            logger.error('Could not parse SLCAN frame [%r]', message, exc_info=True)
             return
 
     def receive(self, timeout=None):
@@ -291,6 +291,7 @@ if __name__ == "__main__":
         import monotonic
         time.monotonic = monotonic.monotonic
 
+    import logging
     logging.basicConfig(stream=sys.stderr, level=logging.DEBUG,
                         format='%(asctime)s %(levelname)s %(name)s: %(message)s')
 

--- a/uavcan/driver.py
+++ b/uavcan/driver.py
@@ -295,8 +295,8 @@ class SLCAN(object):
         return self._parse(msg)
 
     def send(self, message_id, message, extended=False):
-        start = ('T{0:08X}' if extended else 't{0:03X}').format(message_id).encode()
-        line = '{0:s}{1:1d}{2:s}\r'.format(start, len(message), binascii.b2a_hex(message)).encode()
+        start = ('T{0:08X}' if extended else 't{0:03X}').format(message_id)
+        line = '{0:s}{1:1d}{2:s}\r'.format(start, len(message), binascii.b2a_hex(message).decode()).encode()
         self.conn.write(line)
         self.conn.flush()
 

--- a/uavcan/driver.py
+++ b/uavcan/driver.py
@@ -1,4 +1,4 @@
-#encoding=utf-8
+# encoding=utf-8
 
 from __future__ import division, absolute_import, print_function, unicode_literals
 import os
@@ -41,7 +41,7 @@ try:
         return s
 
 except Exception:
-    import ctypes
+    import ctypes  # @UnusedImport
     import ctypes.util
     libc = ctypes.CDLL(ctypes.util.find_library("c"))
 
@@ -54,13 +54,13 @@ except Exception:
 
     from socket import SOL_SOCKET
 
-    SOL_CAN_BASE            = 100
-    SOL_CAN_RAW             = SOL_CAN_BASE + CAN_RAW
-    CAN_RAW_FILTER          = 1     # set 0 .. n can_filter(s)
-    CAN_RAW_ERR_FILTER      = 2     # set filter for error frames
-    CAN_RAW_LOOPBACK        = 3     # local loopback (default:on)
-    CAN_RAW_RECV_OWN_MSGS   = 4     # receive my own msgs (default:off)
-    CAN_RAW_FD_FRAMES       = 5     # allow CAN FD frames (default:off)
+    SOL_CAN_BASE = 100
+    SOL_CAN_RAW = SOL_CAN_BASE + CAN_RAW
+    CAN_RAW_FILTER = 1                      # set 0 .. n can_filter(s)
+    CAN_RAW_ERR_FILTER = 2                  # set filter for error frames
+    CAN_RAW_LOOPBACK = 3                    # local loopback (default:on)
+    CAN_RAW_RECV_OWN_MSGS = 4               # receive my own msgs (default:off)
+    CAN_RAW_FD_FRAMES = 5                   # allow CAN FD frames (default:off)
 
     class sockaddr_can(ctypes.Structure):
         """
@@ -291,7 +291,7 @@ def make_driver(device_name, **kwargs):
 
 if __name__ == "__main__":
     if sys.version_info[0] < 3:
-        import monotonic
+        import monotonic  # @UnresolvedImport
         time.monotonic = monotonic.monotonic
 
     import logging

--- a/uavcan/driver.py
+++ b/uavcan/driver.py
@@ -191,8 +191,6 @@ class SocketCAN(object):
             return RxFrame(can_id & CAN_EFF_MASK, can_data[0:can_dlc], bool(can_id & CAN_EFF_FLAG))
 
     def send(self, message_id, message, extended=False):
-        logger.debug("CAN.send({!r}, {!r}, {!r})".format(message_id, binascii.hexlify(message), extended))
-
         if extended:
             message_id |= CAN_EFF_FLAG
 
@@ -323,10 +321,6 @@ if __name__ == "__main__":
     if sys.version_info[0] < 3:
         import monotonic  # @UnresolvedImport
         time.monotonic = monotonic.monotonic
-
-    import logging
-    logging.basicConfig(stream=sys.stderr, level=logging.DEBUG,
-                        format='%(asctime)s %(levelname)s %(name)s: %(message)s')
 
     if len(sys.argv) < 2:
         print("Usage: driver.py <can-device> [param=value ...]")

--- a/uavcan/driver.py
+++ b/uavcan/driver.py
@@ -291,7 +291,9 @@ class SLCAN(object):
                     return
                 self.conn.timeout = to
 
-            self._read_buffer += self.conn.read(1)
+            b = self.conn.read(1)
+            if b != self.NACK:
+                self._read_buffer += b
 
         assert self._read_buffer.endswith(b'\r')
 
@@ -324,8 +326,11 @@ def make_driver(device_name, **kwargs):
 
 if __name__ == "__main__":
     if sys.version_info[0] < 3:
-        import monotonic  # @UnresolvedImport
-        time.monotonic = monotonic.monotonic
+        try:
+            import monotonic  # @UnresolvedImport
+            time.monotonic = monotonic.monotonic
+        except ImportError:
+            time.monotonic = time.time
 
     if len(sys.argv) < 2:
         print("Usage: driver.py <can-device> [param=value ...]")

--- a/uavcan/driver.py
+++ b/uavcan/driver.py
@@ -1,5 +1,6 @@
 #encoding=utf-8
 
+from __future__ import division, absolute_import, print_function, unicode_literals
 import os
 import sys
 import time

--- a/uavcan/dsdl/__init__.py
+++ b/uavcan/dsdl/__init__.py
@@ -1,5 +1,10 @@
 #
-# Copyright (C) 2014 Pavel Kirienko <pavel.kirienko@gmail.com>
+# Copyright (C) 2014-2015  UAVCAN Development Team  <uavcan.org>
+#
+# This software is distributed under the terms of the MIT License.
+#
+# Author: Pavel Kirienko <pavel.kirienko@zubax.com>
+#         Ben Dyer <ben_dyer@mac.com>
 #
 
 '''
@@ -8,8 +13,8 @@ Please read the specs at http://uavcan.org.
 '''
 
 from .parser import Parser, parse_namespaces, \
-                    Type, PrimitiveType, ArrayType, CompoundType, \
-                    Attribute, Field, Constant
+    Type, PrimitiveType, ArrayType, CompoundType, \
+    Attribute, Field, Constant
 
 from .common import DsdlException
 

--- a/uavcan/dsdl/common.py
+++ b/uavcan/dsdl/common.py
@@ -5,8 +5,10 @@
 from __future__ import division, absolute_import, print_function, unicode_literals
 import os
 import struct
+from uavcan import UAVCANException
 
-class DsdlException(Exception):
+
+class DsdlException(UAVCANException):
     '''
     This exception is raised in case of a parser failure.
     Fields:

--- a/uavcan/dsdl/common.py
+++ b/uavcan/dsdl/common.py
@@ -1,5 +1,10 @@
 #
-# Copyright (C) 2014 Pavel Kirienko <pavel.kirienko@gmail.com>
+# Copyright (C) 2014-2015  UAVCAN Development Team  <uavcan.org>
+#
+# This software is distributed under the terms of the MIT License.
+#
+# Author: Pavel Kirienko <pavel.kirienko@zubax.com>
+#         Ben Dyer <ben_dyer@mac.com>
 #
 
 from __future__ import division, absolute_import, print_function, unicode_literals
@@ -15,6 +20,7 @@ class DsdlException(UAVCANException):
         file    Source file path where the error has occurred. Optional, will be None if unknown.
         line    Source file line number where the error has occurred. Optional, will be None if unknown.
     '''
+
     def __init__(self, text, file=None, line=None):
         Exception.__init__(self, text)
         self.file = file

--- a/uavcan/dsdl/parser.py
+++ b/uavcan/dsdl/parser.py
@@ -1,7 +1,10 @@
 #
-# UAVCAN DSDL file parser
+# Copyright (C) 2014-2015  UAVCAN Development Team  <uavcan.org>
 #
-# Copyright (C) 2014-2015 Pavel Kirienko <pavel.kirienko@gmail.com>
+# This software is distributed under the terms of the MIT License.
+#
+# Author: Pavel Kirienko <pavel.kirienko@zubax.com>
+#         Ben Dyer <ben_dyer@mac.com>
 #
 
 from __future__ import division, absolute_import, print_function, unicode_literals

--- a/uavcan/dsdl/signature.py
+++ b/uavcan/dsdl/signature.py
@@ -1,7 +1,10 @@
 #
-# UAVCAN DSDL signature computation
+# Copyright (C) 2014-2015  UAVCAN Development Team  <uavcan.org>
 #
-# Copyright (C) 2014 Pavel Kirienko <pavel.kirienko@gmail.com>
+# This software is distributed under the terms of the MIT License.
+#
+# Author: Pavel Kirienko <pavel.kirienko@zubax.com>
+#         Ben Dyer <ben_dyer@mac.com>
 #
 
 from __future__ import division, absolute_import, print_function, unicode_literals
@@ -15,6 +18,8 @@ from __future__ import division, absolute_import, print_function, unicode_litera
 # Output xor: 0xFFFFFFFFFFFFFFFF
 # Check: 0x62EC59E3F1A4F00A
 #
+
+
 class Signature:
     '''
     This class implements the UAVCAN DSDL signature hash function. Please refer to the specification for details.

--- a/uavcan/dsdl/type_limits.py
+++ b/uavcan/dsdl/type_limits.py
@@ -1,20 +1,26 @@
 #
-# UAVCAN DSDL type range limits
+# Copyright (C) 2014-2015  UAVCAN Development Team  <uavcan.org>
 #
-# Copyright (C) 2014 Pavel Kirienko <pavel.kirienko@gmail.com>
+# This software is distributed under the terms of the MIT License.
+#
+# Author: Pavel Kirienko <pavel.kirienko@zubax.com>
+#         Ben Dyer <ben_dyer@mac.com>
 #
 
 from __future__ import division, absolute_import, print_function, unicode_literals
 from .common import DsdlException
+
 
 def get_unsigned_integer_range(bitlen):
     if not 1 <= bitlen <= 64:
         raise DsdlException('Invalid bit length for integer type: %d' % bitlen)
     return 0, (1 << bitlen) - 1
 
+
 def get_signed_integer_range(bitlen):
     _, uint_max = get_unsigned_integer_range(bitlen)
     return -int(uint_max / 2) - 1, int(uint_max / 2)
+
 
 def get_float_range(bitlen):
     try:

--- a/uavcan/monitors/__init__.py
+++ b/uavcan/monitors/__init__.py
@@ -24,7 +24,7 @@ class NodeStatusMonitor(object):
             self.monotonic_timestamp = None
 
         def _update_from_status(self, e):
-            self.monotonic_timestamp = time.monotonic()
+            self.monotonic_timestamp = e.transfer.ts_monotonic
             self.node_id = e.transfer.source_node_id
             if self.status and e.message.uptime_sec < self.status.uptime_sec:
                 self.info = None
@@ -35,7 +35,7 @@ class NodeStatusMonitor(object):
                     self.info.status.fields[fld] = self.status.fields[fld]
 
         def _update_from_info(self, e):
-            self.monotonic_timestamp = time.monotonic()
+            self.monotonic_timestamp = e.transfer.ts_monotonic
             self.node_id = e.transfer.source_node_id
             self.status = e.response.status
             self.info = e.response
@@ -276,7 +276,7 @@ class DynamicNodeIDServer(object):
         if e.message.first_part_of_unique_id:
             # First-phase messages trigger a second-phase query
             self._query = e.message.unique_id.to_bytes()
-            self._query_timestamp = time.monotonic()
+            self._query_timestamp = e.transfer.ts_monotonic
 
             response = uavcan.protocol.dynamic_node_id.Allocation()  # @UndefinedVariable
             response.first_part_of_unique_id = 0
@@ -289,7 +289,7 @@ class DynamicNodeIDServer(object):
         elif len(e.message.unique_id) == 6 and len(self._query) == 6:
             # Second-phase messages trigger a third-phase query
             self._query += e.message.unique_id.to_bytes()
-            self._query_timestamp = time.monotonic()
+            self._query_timestamp = e.transfer.ts_monotonic
 
             response = uavcan.protocol.dynamic_node_id.Allocation()  # @UndefinedVariable
             response.first_part_of_unique_id = 0
@@ -301,7 +301,7 @@ class DynamicNodeIDServer(object):
         elif len(e.message.unique_id) == 4 and len(self._query) == 12:
             # Third-phase messages trigger an allocation
             self._query += e.message.unique_id.to_bytes()
-            self._query_timestamp = time.monotonic()
+            self._query_timestamp = e.transfer.ts_monotonic
 
             logger.debug("[DynamicNodeIDServer] Got third-stage dynamic ID request for {0!r}".format(self._query))
 

--- a/uavcan/monitors/__init__.py
+++ b/uavcan/monitors/__init__.py
@@ -296,7 +296,7 @@ class DynamicNodeIDServer(object):
         # The local state must be reset after the specified timeout
         if len(self._query) and time.monotonic() - self._query_timestamp > DynamicNodeIDServer.QUERY_TIMEOUT:
             self._query = bytes()
-            logger.error("[DynamicNodeIDServer] Query timeout, resetting query")
+            logger.info("[DynamicNodeIDServer] Query timeout, resetting query")
 
         # Handling the message
         if e.message.first_part_of_unique_id:

--- a/uavcan/monitors/__init__.py
+++ b/uavcan/monitors/__init__.py
@@ -57,6 +57,8 @@ class NodeStatusMonitor(object):
         def __str__(self):
             return '%d:%s' % (self.node_id, self.info if self.info else self.status)
 
+        __repr__ = __str__
+
     class UpdateEvent:
         EVENT_ID_NEW = 'new'
         EVENT_ID_INFO_UPDATE = 'info_update'
@@ -68,6 +70,8 @@ class NodeStatusMonitor(object):
 
         def __str__(self):
             return self.event_id + ':' + str(self.entry)
+
+        __repr__ = __str__
 
     class UpdateHandlerRemover:
         def __init__(self, remover):

--- a/uavcan/monitors/__init__.py
+++ b/uavcan/monitors/__init__.py
@@ -1,3 +1,12 @@
+#
+# Copyright (C) 2014-2015  UAVCAN Development Team  <uavcan.org>
+#
+# This software is distributed under the terms of the MIT License.
+#
+# Author: Ben Dyer <ben_dyer@mac.com>
+#         Pavel Kirienko <pavel.kirienko@zubax.com>
+#
+
 from __future__ import division, absolute_import, print_function, unicode_literals
 import time
 import sqlite3

--- a/uavcan/monitors/__init__.py
+++ b/uavcan/monitors/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import division, absolute_import, print_function, unicode_literals
 import time
 import collections
+import sqlite3
 from logging import getLogger
 
 import uavcan
@@ -42,12 +43,50 @@ class NodeStatusMonitor(object):
         def __str__(self):
             return '%d:%s' % (self.node_id, self.info if self.info else self.status)
 
-        __repr__ = __str__
+    class UpdateEvent:
+        EVENT_ID_NEW = 'new'
+        EVENT_ID_INFO_UPDATE = 'info_update'
+        EVENT_ID_OFFLINE = 'offline'
 
-    def __init__(self, node, on_info_update_callback=None):
-        self.on_info_update_callback = on_info_update_callback
+        def __init__(self, entry, event_id):
+            self.entry = entry
+            self.event_id = event_id
+
+        def __str__(self):
+            return self.event_id + ':' + str(self.entry)
+
+    class UpdateHandlerRemover:
+        def __init__(self, remover):
+            self._remover = remover
+
+        def remove(self):
+            self._remover()
+
+        def try_remove(self):
+            try:
+                self._remover()
+            except ValueError:
+                pass
+
+    def __init__(self, node):
+        self._update_callbacks = []
         self._handle = node.add_handler(uavcan.protocol.NodeStatus, self._on_node_status)  # @UndefinedVariable
         self._registry = {}  # {node_id: Entry}
+        self._timer = node.periodic(1, self._remove_stale)
+
+    def add_update_handler(self, callback):
+        """The specified callback will be invoked when:
+        - A new node appears
+        - Node info for an existing node gets updated
+        - Node goes offline
+        Call remove() or try_remove() on the returned object to unregister the handler.
+        """
+        self._update_callbacks.append(callback)
+        return self.UpdateHandlerRemover(lambda: self._update_callbacks.remove(callback))
+
+    def _call_event_handlers(self, event):
+        for cb in self._update_callbacks:
+            cb(event)
 
     def exists(self, node_id):
         """Returns True if the given node ID exists, false otherwise
@@ -59,6 +98,8 @@ class NodeStatusMonitor(object):
         If the requested node ID does not exist, throws KeyError.
         """
         if (self._registry[node_id].monotonic_timestamp + self.TIMEOUT) < time.monotonic():
+            self._call_event_handlers(self.UpdateEvent(self._registry[node_id],
+                                                       self.UpdateEvent.EVENT_ID_OFFLINE))
             del self._registry[node_id]
         return self._registry[node_id]
 
@@ -78,18 +119,29 @@ class NodeStatusMonitor(object):
         """Stops the instance. The registry will not be cleared.
         """
         self._handle.remove()
+        self._timer.remove()
+
+    def _remove_stale(self):
+        for nid, e in list(self._registry.items())[:]:
+            if (e.monotonic_timestamp + self.TIMEOUT) < time.monotonic():
+                del self._registry[nid]
+                self._call_event_handlers(self.UpdateEvent(e, self.UpdateEvent.EVENT_ID_OFFLINE))
 
     def _on_node_status(self, e):
         node_id = e.transfer.source_node_id
 
         try:
             entry = self.get(node_id)
+            new_entry = False
         except KeyError:
             entry = self.Entry()
             entry._info_requested_at = 0
             self._registry[node_id] = entry
+            new_entry = True
 
         entry._update_from_status(e)
+        if new_entry:
+            self._call_event_handlers(self.UpdateEvent(entry, self.UpdateEvent.EVENT_ID_NEW))
 
         if not entry.info and entry.monotonic_timestamp - entry._info_requested_at > self.RETRY_INTERVAL:
             entry._info_requested_at = entry.monotonic_timestamp
@@ -132,38 +184,92 @@ class NodeStatusMonitor(object):
         )
         logger.info(msg)
 
-        if self.on_info_update_callback:
-            self.on_info_update_callback(entry)
+        self._call_event_handlers(self.UpdateEvent(entry, self.UpdateEvent.EVENT_ID_INFO_UPDATE))
 
 
 class DynamicNodeIDServer(object):
     QUERY_TIMEOUT = uavcan.protocol.dynamic_node_id.Allocation().FOLLOWUP_TIMEOUT_MS / 1000  # @UndefinedVariable
     DEFAULT_NODE_ID_RANGE = 1, 125
+    DATABASE_STORAGE_MEMORY = ':memory:'
 
-    def __init__(self, node, node_status_monitor, dynamic_node_id_range=None):
+    class AllocationTable(object):
+        def __init__(self, path):
+            assert isinstance(path, str)
+            self.db = sqlite3.connect(path)  # @UndefinedVariable
+
+            self._modify('''CREATE TABLE IF NOT EXISTS `allocation` (
+            `node_id`   INTEGER NOT NULL UNIQUE,
+            `unique_id` blob,
+            `ts`        time NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY(node_id));''')
+
+        def _modify(self, what, *args):
+            c = self.db.cursor()
+            c.execute(what, args)   # Tuple!
+            self.db.commit()
+
+        def close(self):
+            self.db.close()
+
+        def set(self, unique_id, node_id):
+            if unique_id is not None and unique_id == bytes([0] * len(unique_id)):
+                unique_id = None
+            logger.debug('[DynamicNodeIDServer] AllocationTable update: #{0:03d} {1!r}'.format(node_id, unique_id))
+            self._modify('''insert or replace into allocation (node_id, unique_id) values (?, ?);''',
+                         node_id, unique_id)
+
+        def get_node_id(self, unique_id):
+            assert isinstance(unique_id, bytes)
+            c = self.db.cursor()
+            c.execute('''select node_id from allocation where unique_id = ? order by ts desc limit 1''',
+                      (unique_id,))
+            res = c.fetchone()
+            return res[0] if res else None
+
+        def get_unique_id(self, node_id):
+            assert isinstance(node_id, int)
+            c = self.db.cursor()
+            c.execute('''select unique_id from allocation where node_id = ?''', (node_id,))
+            res = c.fetchone()
+            return res[0] if res else None
+
+        def get_all_node_id(self):
+            c = self.db.cursor()
+            c.execute('''select node_id from allocation order by ts desc''')
+            return [x for x, in c.fetchall()]
+
+    def __init__(self, node, node_status_monitor, database_storage=None, dynamic_node_id_range=None):
         """
-        :param node: Node instance
-        :param node_status_monitor: Instance of NodeStatusMonitor
-        :param dynamic_node_id_range: Range of node ID available for dynamic allocation; defaults to [1, 125]
+        :param node: Node instance.
+
+        :param node_status_monitor: Instance of NodeStatusMonitor.
+
+        :param database_storage: Path to the file where the instance will keep the allocation table.
+                                 If not provided, the allocation table will be kept in memory.
+
+        :param dynamic_node_id_range: Range of node ID available for dynamic allocation; defaults to [1, 125].
         """
-        self._allocation_table = {}  # {unique_id: node_id}
+        self._allocation_table = DynamicNodeIDServer.AllocationTable(database_storage or self.DATABASE_STORAGE_MEMORY)
         self._query = bytes()
         self._query_timestamp = 0
-        self._node_monitor = node_status_monitor
+        self._node_monitor_event_handle = node_status_monitor.add_update_handler(self._handle_monitor_event)
 
         self._dynamic_node_id_range = dynamic_node_id_range or DynamicNodeIDServer.DEFAULT_NODE_ID_RANGE
         self._handle = node.add_handler(uavcan.protocol.dynamic_node_id.Allocation,  # @UndefinedVariable
                                         self._on_allocation_message)
 
+        self._allocation_table.set(node.node_info.hardware_version.unique_id.to_bytes(), node.node_id)
+
+    def _handle_monitor_event(self, event):
+        unique_id = event.entry.info.hardware_version.unique_id.to_bytes() if event.entry.info else None
+        self._allocation_table.set(unique_id, event.entry.node_id)
+
     def stop(self):
-        """Stops the instance.
+        """Stops the instance and closes the allocation table storage.
         """
         self._handle.remove()
-
-    def get_allocated_node_id(self):
-        """Returns a generator or an iterable containing all node ID that were allocated by this allocator.
-        """
-        return self._allocation_table.values()
+        self._node_monitor_event_handle.remove()
+        self._allocation_table.close()
 
     def _on_allocation_message(self, e):
         # TODO: request validation
@@ -200,20 +306,13 @@ class DynamicNodeIDServer(object):
             logger.debug("[DynamicNodeIDServer] Got third-stage dynamic ID request for {0!r}".format(self._query))
 
             node_requested_id = e.message.node_id
-            node_allocated_id = None
-
-            allocated_node_ids = set(self._allocation_table.values()) | set(self._node_monitor.get_all_node_id())
-            allocated_node_ids.add(e.node.node_id)
-
-            # If we've already allocated a node ID to this device, return the same one
-            if self._query in self._allocation_table:
-                node_allocated_id = self._allocation_table[self._query]
+            node_allocated_id = self._allocation_table.get_node_id(self._query)
 
             # If an ID was requested but not allocated yet, allocate the first
             # ID equal to or higher than the one that was requested
             if node_requested_id and not node_allocated_id:
                 for node_id in range(node_requested_id, self._dynamic_node_id_range[1]):
-                    if node_id not in allocated_node_ids:
+                    if not self._allocation_table.get_unique_id(node_id):
                         node_allocated_id = node_id
                         break
 
@@ -221,11 +320,11 @@ class DynamicNodeIDServer(object):
             # ID was zero), allocate the highest unallocated node ID
             if not node_allocated_id:
                 for node_id in range(self._dynamic_node_id_range[1], self._dynamic_node_id_range[0], -1):
-                    if node_id not in allocated_node_ids:
+                    if not self._allocation_table.get_unique_id(node_id):
                         node_allocated_id = node_id
                         break
 
-            self._allocation_table[self._query] = node_allocated_id
+            self._allocation_table.set(self._query, node_allocated_id)
 
             if node_allocated_id:
                 response = uavcan.protocol.dynamic_node_id.Allocation()  # @UndefinedVariable

--- a/uavcan/monitors/__init__.py
+++ b/uavcan/monitors/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import division, absolute_import, print_function, unicode_literals
 import time
 import logging
 import collections

--- a/uavcan/monitors/__init__.py
+++ b/uavcan/monitors/__init__.py
@@ -212,7 +212,8 @@ class DynamicNodeIDServer(object):
 
     class AllocationTable(object):
         def __init__(self, path):
-            self.db = sqlite3.connect(path)  # @UndefinedVariable
+            # Disabling same thread check on the assumption that the developer knows what they are doing.
+            self.db = sqlite3.connect(path, check_same_thread=False)  # @UndefinedVariable
 
             self._modify('''CREATE TABLE IF NOT EXISTS `allocation` (
             `node_id`   INTEGER NOT NULL UNIQUE,

--- a/uavcan/monitors/__init__.py
+++ b/uavcan/monitors/__init__.py
@@ -24,19 +24,17 @@ class NodeStatusMonitor(uavcan.node.Monitor):
         node_id = self.transfer.source_node_id
         last_timestamp = NodeStatusMonitor.NODE_TIMESTAMP[node_id]
         last_node_uptime = NodeStatusMonitor.NODE_STATUS[node_id].uptime_sec \
-                           if node_id in NodeStatusMonitor.NODE_STATUS else 0
+            if node_id in NodeStatusMonitor.NODE_STATUS else 0
 
         # Update the node status registry
         NodeStatusMonitor.NODE_STATUS[node_id] = message
         NodeStatusMonitor.NODE_TIMESTAMP[node_id] = time.monotonic()
 
-        if time.monotonic() - last_timestamp > NodeStatusMonitor.TIMEOUT or \
-                message.uptime_sec < last_node_uptime:
+        if time.monotonic() - last_timestamp > NodeStatusMonitor.TIMEOUT or message.uptime_sec < last_node_uptime:
             # The node has timed out, hasn't been seen before, or has
             # restarted, so get the node's hardware and software info
-            request = uavcan.protocol.GetNodeInfo(mode="request")
-            self.node.send_request(request, node_id,
-                                   callback=self.on_nodeinfo_response)
+            request = uavcan.protocol.GetNodeInfo(mode="request")  # @UndefinedVariable
+            self.node.send_request(request, node_id, callback=self.on_nodeinfo_response)
 
     def on_nodeinfo_response(self, response, transfer):
         if not response or not transfer:
@@ -71,8 +69,7 @@ class NodeStatusMonitor(uavcan.node.Monitor):
 
         # If a new-node callback is defined, call it now
         if self.new_node_callback:
-            self.new_node_callback(self.node, transfer.source_node_id,
-                                   response)
+            self.new_node_callback(self.node, transfer.source_node_id, response)
 
 
 class DynamicNodeIDServer(uavcan.node.Monitor):
@@ -91,55 +88,47 @@ class DynamicNodeIDServer(uavcan.node.Monitor):
             DynamicNodeIDServer.QUERY = message.unique_id.to_bytes()
             DynamicNodeIDServer.QUERY_TIME = time.monotonic()
 
-            response = uavcan.protocol.dynamic_node_id.Allocation()
+            response = uavcan.protocol.dynamic_node_id.Allocation()  # @UndefinedVariable
             response.first_part_of_unique_id = 0
             response.node_id = 0
             response.unique_id.from_bytes(DynamicNodeIDServer.QUERY)
             self.node.send_message(response)
 
-            logger.debug(("[MASTER] Got first-stage dynamic ID request " +
-                           "for {0!r}").format(DynamicNodeIDServer.QUERY))
-        elif len(message.unique_id) == 6 and \
-                len(DynamicNodeIDServer.QUERY) == 6:
+            logger.debug("[MASTER] Got first-stage dynamic ID request for {0!r}".format(DynamicNodeIDServer.QUERY))
+        elif len(message.unique_id) == 6 and len(DynamicNodeIDServer.QUERY) == 6:
             # Second-phase messages trigger a third-phase query
             DynamicNodeIDServer.QUERY += message.unique_id.to_bytes()
             DynamicNodeIDServer.QUERY_TIME = time.monotonic()
 
-            response = uavcan.protocol.dynamic_node_id.Allocation()
+            response = uavcan.protocol.dynamic_node_id.Allocation()  # @UndefinedVariable
             response.first_part_of_unique_id = 0
             response.node_id = 0
             response.unique_id.from_bytes(DynamicNodeIDServer.QUERY)
             self.node.send_message(response)
-            logger.debug(("[MASTER] Got second-stage dynamic ID request " +
-                           "for {0!r}").format(DynamicNodeIDServer.QUERY))
-        elif len(message.unique_id) == 4 and \
-                len(DynamicNodeIDServer.QUERY) == 12:
+            logger.debug("[MASTER] Got second-stage dynamic ID request for {0!r}".format(DynamicNodeIDServer.QUERY))
+        elif len(message.unique_id) == 4 and len(DynamicNodeIDServer.QUERY) == 12:
             # Third-phase messages trigger an allocation
             DynamicNodeIDServer.QUERY += message.unique_id.to_bytes()
             DynamicNodeIDServer.QUERY_TIME = time.monotonic()
 
-            logger.debug(("[MASTER] Got third-stage dynamic ID request " +
-                           "for {0!r}").format(DynamicNodeIDServer.QUERY))
+            logger.debug("[MASTER] Got third-stage dynamic ID request for {0!r}".format(DynamicNodeIDServer.QUERY))
 
             node_requested_id = message.node_id
             node_allocated_id = None
 
             allocated_node_ids = \
-                set(DynamicNodeIDServer.ALLOCATION.itervalues()) | \
-                set(NodeStatusMonitor.NODE_STATUS.iterkeys())
+                set(DynamicNodeIDServer.ALLOCATION.itervalues()) | set(NodeStatusMonitor.NODE_STATUS.iterkeys())
             allocated_node_ids.add(self.node.node_id)
 
             # If we've already allocated a node ID to this device, return the
             # same one
             if DynamicNodeIDServer.QUERY in DynamicNodeIDServer.ALLOCATION:
-                node_allocated_id = DynamicNodeIDServer.ALLOCATION[
-                    DynamicNodeIDServer.QUERY]
+                node_allocated_id = DynamicNodeIDServer.ALLOCATION[DynamicNodeIDServer.QUERY]
 
             # If an ID was requested but not allocated yet, allocate the first
             # ID equal to or higher than the one that was requested
             if node_requested_id and not node_allocated_id:
-                for node_id in xrange(node_requested_id,
-                                      self.dynamic_id_range[1]):
+                for node_id in range(node_requested_id, self.dynamic_id_range[1]):
                     if node_id not in allocated_node_ids:
                         node_allocated_id = node_id
                         break
@@ -147,29 +136,24 @@ class DynamicNodeIDServer(uavcan.node.Monitor):
             # If no ID was allocated in the above step (also if the requested
             # ID was zero), allocate the highest unallocated node ID
             if not node_allocated_id:
-                for node_id in xrange(self.dynamic_id_range[1],
-                                      self.dynamic_id_range[0], -1):
+                for node_id in range(self.dynamic_id_range[1], self.dynamic_id_range[0], -1):
                     if node_id not in allocated_node_ids:
                         node_allocated_id = node_id
                         break
 
-            DynamicNodeIDServer.ALLOCATION[DynamicNodeIDServer.QUERY] = \
-                node_allocated_id
+            DynamicNodeIDServer.ALLOCATION[DynamicNodeIDServer.QUERY] = node_allocated_id
 
             if node_allocated_id:
-                response = uavcan.protocol.dynamic_node_id.Allocation()
+                response = uavcan.protocol.dynamic_node_id.Allocation()  # @UndefinedVariable
                 response.first_part_of_unique_id = 0
                 response.node_id = node_allocated_id
-                response.unique_id.from_bytes(
-                    DynamicNodeIDServer.QUERY)
+                response.unique_id.from_bytes(DynamicNodeIDServer.QUERY)
                 self.node.send_message(response)
-                logger.info(("[MASTER] Allocated node ID #{0:03d} to node " +
-                              "with unique ID {1!r}").format(
-                              node_allocated_id, DynamicNodeIDServer.QUERY))
+                logger.info("[MASTER] Allocated node ID #{0:03d} to node with unique ID {1!r}"
+                            .format(node_allocated_id, DynamicNodeIDServer.QUERY))
             else:
                 logger.error("[MASTER] Couldn't allocate dynamic node ID")
-        elif time.monotonic() - DynamicNodeIDServer.QUERY_TIME > \
-                DynamicNodeIDServer.QUERY_TIMEOUT:
+        elif time.monotonic() - DynamicNodeIDServer.QUERY_TIME > DynamicNodeIDServer.QUERY_TIMEOUT:
             # Mis-sequenced reply and no good replies during the timeout
             # period -- reset the query now.
             DynamicNodeIDServer.QUERY = ""
@@ -178,8 +162,6 @@ class DynamicNodeIDServer(uavcan.node.Monitor):
 
 class DebugLogMessageMonitor(uavcan.node.Monitor):
     def on_message(self, message):
-        logmsg = "DebugLogMessageMonitor [#{0:03d}:{1}] {2}".format(
-            self.transfer.source_node_id, message.source.decode(),
-            message.text.decode())
-        (logger.debug, logger.info,
-            logger.warning, logger.error)[message.level.value](logmsg)
+        logmsg = "DebugLogMessageMonitor [#{0:03d}:{1}] {2}"\
+            .format(self.transfer.source_node_id, message.source.decode(), message.text.decode())
+        (logger.debug, logger.info, logger.warning, logger.error)[message.level.value](logmsg)

--- a/uavcan/monitors/__init__.py
+++ b/uavcan/monitors/__init__.py
@@ -1,8 +1,13 @@
 from __future__ import division, absolute_import, print_function, unicode_literals
 import time
-import collections
 import sqlite3
 from logging import getLogger
+
+import collections
+try:
+    collections_abc = collections.abc
+except AttributeError:
+    collections_abc = collections
 
 import uavcan
 import uavcan.node
@@ -359,3 +364,51 @@ class DebugLogMessageMonitor(object):
         logmsg = "DebugLogMessageMonitor [#{0:03d}:{1}] {2}"\
             .format(e.transfer.source_node_id, e.message.source.decode(), e.message.text.decode())
         (logger.debug, logger.info, logger.warning, logger.error)[e.message.level.value](logmsg)
+
+
+class MessageCollector(collections_abc.Mapping):
+    """This class keeps the latest TransferEvent of a given message type categorized by specified key.
+    The stored items can be automatically removed if they were not updated in a specified time interval.
+
+    Defaults are as follows:
+     - Categorization key: source node ID
+     - Entry timeout: infinite
+    """
+
+    def __init__(self, node, data_type, key=None, timeout=None):
+        """
+        :param node: Node instance.
+
+        :param data_type: Data type to subscribe to.
+
+        :param key: A callable that accepts a TransferEvent instance and returns a hashable.
+                    The returned hashable will be used as categorization key.
+                    If this argument is not provided, the messages will be categorized by source node ID.
+
+        :param timeout: Entry timeout. If an entry was not updated in this time, it will be removed.
+                        By default entry lifetime is not limited.
+        """
+        self._handle = node.add_handler(data_type, lambda e: self._storage.update({self._key_function(e): e}))
+        self._storage = {}
+        self._key_function = key or (lambda e: e.transfer.source_node_id)
+        self._timeout = timeout
+
+    def stop(self):
+        self._handle.remove()
+
+    def __getitem__(self, key):
+        if self._timeout is not None:
+            if (self._storage[key].transfer.ts_monotonic + self._timeout) < time.monotonic():
+                del self._storage[key]
+        return self._storage[key]
+
+    def __iter__(self):
+        for x in list(self._storage.keys())[:]:
+            try:
+                self[x]         # __getitem__ is mutating here - it removes outdated entries
+            except KeyError:
+                pass
+        return iter(self._storage)
+
+    def __len__(self):
+        return len(self._storage)

--- a/uavcan/monitors/__init__.py
+++ b/uavcan/monitors/__init__.py
@@ -1,4 +1,3 @@
-import os
 import time
 import logging
 import collections

--- a/uavcan/monitors/__init__.py
+++ b/uavcan/monitors/__init__.py
@@ -34,7 +34,7 @@ class NodeStatusMonitor(uavcan.node.Monitor):
             # The node has timed out, hasn't been seen before, or has
             # restarted, so get the node's hardware and software info
             request = uavcan.protocol.GetNodeInfo(mode="request")  # @UndefinedVariable
-            self.node.send_request(request, node_id, callback=self.on_nodeinfo_response)
+            self.node.request(request, node_id, callback=self.on_nodeinfo_response)
 
     def on_nodeinfo_response(self, response, transfer):
         if not response or not transfer:
@@ -92,7 +92,7 @@ class DynamicNodeIDServer(uavcan.node.Monitor):
             response.first_part_of_unique_id = 0
             response.node_id = 0
             response.unique_id.from_bytes(DynamicNodeIDServer.QUERY)
-            self.node.send_message(response)
+            self.node.broadcast(response)
 
             logger.debug("[MASTER] Got first-stage dynamic ID request for {0!r}".format(DynamicNodeIDServer.QUERY))
         elif len(message.unique_id) == 6 and len(DynamicNodeIDServer.QUERY) == 6:
@@ -104,7 +104,7 @@ class DynamicNodeIDServer(uavcan.node.Monitor):
             response.first_part_of_unique_id = 0
             response.node_id = 0
             response.unique_id.from_bytes(DynamicNodeIDServer.QUERY)
-            self.node.send_message(response)
+            self.node.broadcast(response)
             logger.debug("[MASTER] Got second-stage dynamic ID request for {0!r}".format(DynamicNodeIDServer.QUERY))
         elif len(message.unique_id) == 4 and len(DynamicNodeIDServer.QUERY) == 12:
             # Third-phase messages trigger an allocation
@@ -148,7 +148,7 @@ class DynamicNodeIDServer(uavcan.node.Monitor):
                 response.first_part_of_unique_id = 0
                 response.node_id = node_allocated_id
                 response.unique_id.from_bytes(DynamicNodeIDServer.QUERY)
-                self.node.send_message(response)
+                self.node.broadcast(response)
                 logger.info("[MASTER] Allocated node ID #{0:03d} to node with unique ID {1!r}"
                             .format(node_allocated_id, DynamicNodeIDServer.QUERY))
             else:

--- a/uavcan/monitors/__init__.py
+++ b/uavcan/monitors/__init__.py
@@ -37,6 +37,9 @@ class NodeStatusMonitor(uavcan.node.Monitor):
             self.node.request(request, node_id, callback=self.on_nodeinfo_response)
 
     def on_nodeinfo_response(self, e):
+        if not e:
+            return
+
         NodeStatusMonitor.NODE_INFO[e.transfer.source_node_id] = e.response
 
         hw_unique_id = "".join(format(c, "02X") for c in e.response.hardware_version.unique_id)

--- a/uavcan/monitors/__init__.py
+++ b/uavcan/monitors/__init__.py
@@ -208,7 +208,6 @@ class DynamicNodeIDServer(object):
 
     class AllocationTable(object):
         def __init__(self, path):
-            assert isinstance(path, str)
             self.db = sqlite3.connect(path)  # @UndefinedVariable
 
             self._modify('''CREATE TABLE IF NOT EXISTS `allocation` (
@@ -228,6 +227,8 @@ class DynamicNodeIDServer(object):
         def set(self, unique_id, node_id):
             if unique_id is not None and unique_id == bytes([0] * len(unique_id)):
                 unique_id = None
+            if unique_id is not None:
+                unique_id = sqlite3.Binary(unique_id)
             logger.debug('[DynamicNodeIDServer] AllocationTable update: #{0:03d} {1!r}'.format(node_id, unique_id))
             self._modify('''insert or replace into allocation (node_id, unique_id) values (?, ?);''',
                          node_id, unique_id)

--- a/uavcan/monitors/__init__.py
+++ b/uavcan/monitors/__init__.py
@@ -14,7 +14,7 @@ class NodeStatusMonitor(uavcan.node.Monitor):
     NODE_INFO = {}
     NODE_STATUS = {}
     NODE_TIMESTAMP = collections.defaultdict(float)
-    TIMEOUT = 30.0
+    TIMEOUT = uavcan.protocol.NodeStatus().OFFLINE_TIMEOUT_MS / 1000  # @UndefinedVariable
 
     def __init__(self, *args, **kwargs):
         super(NodeStatusMonitor, self).__init__(*args, **kwargs)

--- a/uavcan/node.py
+++ b/uavcan/node.py
@@ -1,5 +1,6 @@
 #encoding=utf-8
 
+from __future__ import division, absolute_import, print_function, unicode_literals
 import time
 import logging
 import collections

--- a/uavcan/node.py
+++ b/uavcan/node.py
@@ -1,4 +1,4 @@
-#encoding=utf-8
+# encoding=utf-8
 
 from __future__ import division, absolute_import, print_function, unicode_literals
 import time
@@ -22,6 +22,7 @@ class Scheduler(object):
     """This class implements a simple non-blocking event scheduler.
     It supports one-shot and periodic events.
     """
+
     def __init__(self):
         if sys.version_info[0] > 2:
             # Nice and easy.
@@ -119,8 +120,8 @@ class Node(Scheduler):
 
         self.start_time_monotonic = time.monotonic()
 
-        self.health = uavcan.protocol.NodeStatus().HEALTH_OK
-        self.mode = uavcan.protocol.NodeStatus().MODE_INITIALIZATION
+        self.health = uavcan.protocol.NodeStatus().HEALTH_OK            # @UndefinedVariable
+        self.mode = uavcan.protocol.NodeStatus().MODE_INITIALIZATION    # @UndefinedVariable
         self.vendor_specific_status_code = 0
 
         node_status_interval = node_status_interval or DEFAULT_NODE_STATUS_INTERVAL
@@ -170,7 +171,7 @@ class Node(Scheduler):
 
     def _send_node_status(self):
         if self.node_id:
-            msg = uavcan.protocol.NodeStatus()
+            msg = uavcan.protocol.NodeStatus()  # @UndefinedVariable
             msg.uptime_sec = int(time.monotonic() - self.start_time_monotonic + 0.5)
             msg.health = self.health
             msg.mode = self.mode

--- a/uavcan/node.py
+++ b/uavcan/node.py
@@ -55,11 +55,11 @@ class Scheduler(object):
     def _make_sched_handle(self, get_event):
         class EventHandle(object):
             @staticmethod
-            def cancel():
+            def remove():
                 self._scheduler.cancel(get_event())
 
             @staticmethod
-            def try_cancel():
+            def try_remove():
                 try:
                     self._scheduler.cancel(get_event())
                     return True
@@ -74,7 +74,7 @@ class Scheduler(object):
 
     def defer(self, timeout_seconds, callback):
         """This method allows to invoke the callback with specified arguments once the specified amount of time.
-        :returns: EventHandle object. Call .cancel() on it to cancel the event.
+        :returns: EventHandle object. Call .remove() on it to cancel the event.
         """
         priority = 1
         event = self._scheduler.enter(timeout_seconds, priority, callback, ())
@@ -83,7 +83,7 @@ class Scheduler(object):
     def periodic(self, period_seconds, callback):
         """This method allows to invoke the callback periodically, with specified time intervals.
         Note that the scheduler features zero phase drift.
-        :returns: EventHandle object. Call .cancel() on it to cancel the event.
+        :returns: EventHandle object. Call .remove() on it to cancel the event.
         """
         priority = 0
 
@@ -349,7 +349,7 @@ class Node(Scheduler):
 
         # This wrapper will automatically cancel the timeout callback if there was a response
         def timeout_cancelling_wrapper(event):
-            timeout_caller_handle.try_cancel()
+            timeout_caller_handle.try_remove()
             callback(event)
 
         # Registering the pending request using the wrapper above instead of the callback

--- a/uavcan/node.py
+++ b/uavcan/node.py
@@ -1,4 +1,11 @@
-# encoding=utf-8
+#
+# Copyright (C) 2014-2015  UAVCAN Development Team  <uavcan.org>
+#
+# This software is distributed under the terms of the MIT License.
+#
+# Author: Ben Dyer <ben_dyer@mac.com>
+#         Pavel Kirienko <pavel.kirienko@zubax.com>
+#
 
 from __future__ import division, absolute_import, print_function, unicode_literals
 import time

--- a/uavcan/node.py
+++ b/uavcan/node.py
@@ -225,12 +225,11 @@ class Node(Scheduler):
         self.node_info = node_info or uavcan.protocol.GetNodeInfo.Response()     # @UndefinedVariable
         self.add_handler(uavcan.protocol.GetNodeInfo, lambda _: self.node_info)  # @UndefinedVariable
 
-    def _recv_frame(self, message):
-        frame_id, frame_data, ext_id = message
-        if not ext_id:
+    def _recv_frame(self, raw_frame):
+        if not raw_frame.extended:
             return
 
-        frame = transport.Frame(frame_id, frame_data)
+        frame = transport.Frame(raw_frame.id, raw_frame.data, raw_frame.ts_monotonic, raw_frame.ts_real)
         # logger.debug("Node._recv_frame(): got {0!s}".format(frame))
 
         transfer_frames = self._transfer_manager.receive_frame(frame)

--- a/uavcan/node.py
+++ b/uavcan/node.py
@@ -171,13 +171,11 @@ class Node(Scheduler):
 
     def _send_node_status(self):
         if self.node_id:
-            msg = uavcan.protocol.NodeStatus()  # @UndefinedVariable
-            msg.uptime_sec = int(time.monotonic() - self.start_time_monotonic + 0.5)
-            msg.health = self.health
-            msg.mode = self.mode
-            msg.sub_mode = 0
-            msg.vendor_specific_status_code = self.vendor_specific_status_code
-            self.send_message(msg)
+            uptime_sec = int(time.monotonic() - self.start_time_monotonic + 0.5)
+            self.send_message(uavcan.protocol.NodeStatus(uptime_sec=uptime_sec,  # @UndefinedVariable
+                                                         health=self.health,
+                                                         mode=self.mode,
+                                                         vendor_specific_status_code=self.vendor_specific_status_code))
 
     def spin(self, timeout=None):
         """Runs background processes until timeout expires.

--- a/uavcan/node.py
+++ b/uavcan/node.py
@@ -29,7 +29,7 @@ class Scheduler(object):
             self._run_scheduler = lambda: self._scheduler.run(blocking=False)
         else:
             # Nightmare inducing hacks
-            class SayNoToBlockingSchedulingException(Exception):
+            class SayNoToBlockingSchedulingException(uavcan.UAVCANException):
                 pass
 
             def delayfunc_impostor(duration):
@@ -222,7 +222,7 @@ class Node(Scheduler):
 
     def send_message(self, payload):
         if not self.node_id:
-            raise Exception('The node is configured in anonymous mode')  # TODO: use custom exception class
+            raise uavcan.UAVCANException('The node is configured in anonymous mode')
 
         transfer_id = self._next_transfer_id(payload.type.default_dtid)
         transfer = transport.Transfer(payload=payload,

--- a/uavcan/node.py
+++ b/uavcan/node.py
@@ -184,11 +184,12 @@ class HandlerDispatcher(object):
 
 
 class Node(Scheduler):
-    def __init__(self, can_driver, node_id=None, node_status_interval=None, **_extras):
+    def __init__(self, can_driver, node_id=None, node_status_interval=None, mode=None, **_extras):
         """It is recommended to use make_node() rather than instantiating this type directly.
         :param can_driver: CAN bus driver object. Calling close() on a node object closes its driver instance.
         :param node_id: Node ID of the current instance. Defaults to None, which enables passive mode.
         :param node_status_interval: NodeStatus broadcasting interval. Defaults to DEFAULT_NODE_STATUS_INTERVAL.
+        :param mode: Initial operating mode (INITIALIZATION, OPERATIONAL, etc.); defaults to INITIALIZATION.
         """
         super(Node, self).__init__()
 
@@ -204,8 +205,8 @@ class Node(Scheduler):
 
         self.start_time_monotonic = time.monotonic()
 
-        self.health = uavcan.protocol.NodeStatus().HEALTH_OK            # @UndefinedVariable
-        self.mode = uavcan.protocol.NodeStatus().MODE_INITIALIZATION    # @UndefinedVariable
+        self.health = uavcan.protocol.NodeStatus().HEALTH_OK                    # @UndefinedVariable
+        self.mode = mode or uavcan.protocol.NodeStatus().MODE_INITIALIZATION    # @UndefinedVariable
         self.vendor_specific_status_code = 0
 
         node_status_interval = node_status_interval or DEFAULT_NODE_STATUS_INTERVAL

--- a/uavcan/node.py
+++ b/uavcan/node.py
@@ -1,16 +1,10 @@
 #encoding=utf-8
 
 import time
-import math
-import ctypes
-import struct
 import logging
-import binascii
-import functools
 import collections
 
 import uavcan
-import uavcan.dsdl as dsdl
 import uavcan.driver as driver
 import uavcan.transport as transport
 

--- a/uavcan/node.py
+++ b/uavcan/node.py
@@ -237,7 +237,6 @@ class Node(Scheduler):
             return
 
         frame = transport.Frame(raw_frame.id, raw_frame.data, raw_frame.ts_monotonic, raw_frame.ts_real)
-        # logger.debug("Node._recv_frame(): got {0!s}".format(frame))
 
         transfer_frames = self._transfer_manager.receive_frame(frame)
         if not transfer_frames:
@@ -245,8 +244,6 @@ class Node(Scheduler):
 
         transfer = transport.Transfer()
         transfer.from_frames(transfer_frames)
-
-        logger.debug("Node._recv_frame(): received {0!r}".format(transfer))
 
         if (transfer.service_not_message and not transfer.request_not_response) and \
                 transfer.dest_node_id == self.node_id:

--- a/uavcan/node.py
+++ b/uavcan/node.py
@@ -392,8 +392,6 @@ class Node(Scheduler):
         for frame in transfer.to_frames():
             self._can_driver.send(frame.message_id, frame.bytes, extended=True)
 
-        logger.debug("Node.broadcast(): sent {0!r}".format(payload))
-
     def close(self):
         self._can_driver.close()
 

--- a/uavcan/node.py
+++ b/uavcan/node.py
@@ -2,10 +2,10 @@
 
 from __future__ import division, absolute_import, print_function, unicode_literals
 import time
-import logging
 import collections
 import sched
 import sys
+from logging import getLogger
 
 import uavcan
 import uavcan.driver as driver
@@ -13,6 +13,9 @@ import uavcan.transport as transport
 
 
 DEFAULT_NODE_STATUS_INTERVAL = 0.5
+
+
+logger = getLogger(__name__)
 
 
 class Scheduler(object):
@@ -129,7 +132,7 @@ class Node(Scheduler):
             return
 
         frame = transport.Frame(frame_id, frame_data)
-        # logging.debug("Node._recv_frame(): got {0!s}".format(frame))
+        # logger.debug("Node._recv_frame(): got {0!s}".format(frame))
 
         transfer_frames = self._transfer_manager.receive_frame(frame)
         if not transfer_frames:
@@ -138,7 +141,7 @@ class Node(Scheduler):
         transfer = transport.Transfer()
         transfer.from_frames(transfer_frames)
 
-        logging.debug("Node._recv_frame(): received {0!r}".format(transfer))
+        logger.debug("Node._recv_frame(): received {0!r}".format(transfer))
 
         if (transfer.service_not_message and not transfer.request_not_response) and \
                 transfer.dest_node_id == self.node_id:
@@ -215,7 +218,7 @@ class Node(Scheduler):
             self._outstanding_request_callbacks[transfer.key] = callback
             self._outstanding_request_timestamps[transfer.key] = time.monotonic()
 
-        logging.debug("Node.send_request(dest_node_id={0:d}): sent {1!r}".format(dest_node_id, payload))
+        logger.debug("Node.send_request(dest_node_id={0:d}): sent {1!r}".format(dest_node_id, payload))
 
     def send_message(self, payload):
         if not self.node_id:
@@ -230,7 +233,7 @@ class Node(Scheduler):
         for frame in transfer.to_frames():
             self._can_driver.send(frame.message_id, frame.bytes, extended=True)
 
-        logging.debug("Node.send_message(): sent {0!r}".format(payload))
+        logger.debug("Node.send_message(): sent {0!r}".format(payload))
 
     def close(self):
         self._can_driver.close()
@@ -281,8 +284,8 @@ class Service(Monitor):
             self.node.can.send(frame.message_id, frame.bytes,
                                extended=True)
 
-        logging.debug("ServiceHandler._execute(dest_node_id={0:d}): sent {1!r}"
-                      .format(self.transfer.source_node_id, self.response))
+        logger.debug("ServiceHandler._execute(dest_node_id={0:d}): sent {1!r}"
+                     .format(self.transfer.source_node_id, self.response))
 
     def on_request(self):
         pass

--- a/uavcan/node.py
+++ b/uavcan/node.py
@@ -214,8 +214,8 @@ class Node(Scheduler):
         self.start_time_monotonic = time.monotonic()
 
         # NodeStatus publisher
-        self.health = uavcan.protocol.NodeStatus().HEALTH_OK                     # @UndefinedVariable
-        self.mode = mode or uavcan.protocol.NodeStatus().MODE_INITIALIZATION     # @UndefinedVariable
+        self.health = uavcan.protocol.NodeStatus().HEALTH_OK                                    # @UndefinedVariable
+        self.mode = uavcan.protocol.NodeStatus().MODE_INITIALIZATION if mode is None else mode  # @UndefinedVariable
         self.vendor_specific_status_code = 0
 
         node_status_interval = node_status_interval or DEFAULT_NODE_STATUS_INTERVAL

--- a/uavcan/node.py
+++ b/uavcan/node.py
@@ -392,7 +392,7 @@ class Service(object):
         self.request = event.request
         self.transfer = event.transfer
         self.node = event.node
-        self.response = transport.CompoundValue(self.request.type, _tao=True, _mode="response")
+        self.response = transport.CompoundValue(self.request.type, _mode="response")
 
     def on_request(self):
         pass

--- a/uavcan/node.py
+++ b/uavcan/node.py
@@ -3,29 +3,126 @@
 import time
 import logging
 import collections
+import sched
+import sys
 
 import uavcan
 import uavcan.driver as driver
 import uavcan.transport as transport
 
 
-NODE_STATUS_INVERVAL = 0.5
+DEFAULT_NODE_STATUS_INTERVAL = 0.5
 
 
-class Node(object):
-    def __init__(self, handlers, node_id=127):
-        self.can = None
-        self.transfer_manager = transport.TransferManager()
-        self.handlers = handlers
+class Scheduler(object):
+    """This class implements a simple non-blocking event scheduler.
+    It supports one-shot and periodic events.
+    """
+    def __init__(self):
+        if sys.version_info[0] > 2:
+            # Nice and easy.
+            self._scheduler = sched.scheduler()
+            self._run_scheduler = lambda: self._scheduler.run(blocking=False)
+        else:
+            # Nightmare inducing hacks
+            class SayNoToBlockingSchedulingException(Exception):
+                pass
+
+            def delayfunc_impostor(duration):
+                if duration > 0:
+                    raise SayNoToBlockingSchedulingException('No!')
+
+            self._scheduler = sched.scheduler(time.monotonic, delayfunc_impostor)
+
+            def run_scheduler():
+                try:
+                    return self._scheduler.run()
+                except SayNoToBlockingSchedulingException:
+                    q = self._scheduler.queue
+                    return q[0][0] if q else None
+
+            self._run_scheduler = run_scheduler
+
+    def _make_sched_handle(self, get_event):
+        class EventHandle(object):
+            @staticmethod
+            def cancel():
+                self._scheduler.cancel(get_event())
+
+            @staticmethod
+            def try_cancel():
+                try:
+                    self._scheduler.cancel(get_event())
+                    return True
+                except ValueError:
+                    return False
+
+        return EventHandle()
+
+    def _poll_scheduler_and_get_remaining_time_to_next_deadline(self):
+        next_deadline_at = self._run_scheduler()
+        return None if next_deadline_at is None else (next_deadline_at - self._scheduler.timefunc())
+
+    def defer(self, timeout_seconds, callback, *args, **kwargs):
+        """This method allows to invoke the callback with specified arguments once the specified amount of time.
+        :returns: EventHandle object. Call .cancel() on it to cancel the event.
+        """
+        priority = 1
+        event = self._scheduler.enter(timeout_seconds, priority, callback, args, kwargs)
+        return self._make_sched_handle(lambda: event)
+
+    def periodic(self, period_seconds, callback, *args, **kwargs):
+        """This method allows to invoke the callback periodically, with specified time intervals.
+        Note that the scheduler features zero phase drift.
+        :returns: EventHandle object. Call .cancel() on it to cancel the event.
+        """
+        priority = 0
+
+        def caller(scheduled_deadline):
+            # Event MUST be re-registered first in order to ensure that it can be cancelled from the callback
+            scheduled_deadline += period_seconds
+            event_holder[0] = self._scheduler.enterabs(scheduled_deadline, priority, caller, (scheduled_deadline,))
+            callback(*args, **kwargs)
+
+        first_deadline = self._scheduler.timefunc() + period_seconds
+        event_holder = [self._scheduler.enterabs(first_deadline, priority, caller, (first_deadline,))]
+        return self._make_sched_handle(lambda: event_holder[0])
+
+    def has_pending_events(self):
+        """Returns true if there is at least one pending event in the queue.
+        """
+        return not self._scheduler.empty()
+
+
+class Node(Scheduler):
+    def __init__(self, can_driver, node_id=None, node_status_interval=None, **_extras):
+        """It is recommended to use make_node() rather than instantiating this type directly.
+        :param can_driver: CAN bus driver object. Calling close() on a node object closes its driver instance.
+        :param node_id: Node ID of the current instance. Defaults to None, which enables passive mode.
+        :param node_status_interval: NodeStatus broadcasting interval. Defaults to DEFAULT_NODE_STATUS_INTERVAL.
+        """
+        super(Node, self).__init__()
+
+        self._can_driver = can_driver
         self.node_id = node_id
-        self.outstanding_requests = {}
-        self.outstanding_request_callbacks = {}
-        self.outstanding_request_timestamps = {}
-        self.outstanding_request_retries = {}
-        self.next_transfer_ids = collections.defaultdict(int)
-        self.node_info = {}
 
-    def _recv_frame(self, dev, message):
+        self._handlers = []
+        self._transfer_manager = transport.TransferManager()
+        self._outstanding_requests = {}
+        self._outstanding_request_callbacks = {}
+        self._outstanding_request_timestamps = {}
+        self._next_transfer_ids = collections.defaultdict(int)
+
+        self.start_time_monotonic = time.monotonic()
+
+        self.health = uavcan.protocol.NodeStatus().HEALTH_OK
+        self.mode = uavcan.protocol.NodeStatus().MODE_INITIALIZATION
+        self.vendor_specific_status_code = 0
+
+        node_status_interval = node_status_interval or DEFAULT_NODE_STATUS_INTERVAL
+        self.periodic(node_status_interval, self._send_node_status)
+
+    def _recv_frame(self, message):
         frame_id, frame_data, ext_id = message
         if not ext_id:
             return
@@ -33,7 +130,7 @@ class Node(object):
         frame = transport.Frame(frame_id, frame_data)
         # logging.debug("Node._recv_frame(): got {0!s}".format(frame))
 
-        transfer_frames = self.transfer_manager.receive_frame(frame)
+        transfer_frames = self._transfer_manager.receive_frame(frame)
         if not transfer_frames:
             return
 
@@ -42,154 +139,109 @@ class Node(object):
 
         logging.debug("Node._recv_frame(): received {0!r}".format(transfer))
 
-        # If it's a node info request, keep track of the status of each node
-        if transfer.payload.type == uavcan.protocol.NodeStatus:
-            self.node_info[transfer.source_node_id] = {
-                "uptime": transfer.payload.uptime_sec,
-                "health": transfer.payload.health,
-                "mode": transfer.payload.mode,
-                "sub_mode": transfer.payload.sub_mode,
-                "vendor_specific_status_code":
-                    transfer.payload.vendor_specific_status_code,
-                "timestamp": time.time()
-            }
-
-        if (transfer.service_not_message and not
-                transfer.request_not_response) and \
+        if (transfer.service_not_message and not transfer.request_not_response) and \
                 transfer.dest_node_id == self.node_id:
-            # This is a reply to a request we sent. Look up the original
-            # request and call the appropriate callback
-            requests = self.outstanding_requests.keys()
+            # This is a reply to a request we sent. Look up the original request and call the appropriate callback
+            requests = self._outstanding_requests.keys()
             for key in requests:
-                if transfer.is_response_to(self.outstanding_requests[key]):
-                    # Call the request's callback and remove it from the
-                    # active list
-                    self.outstanding_request_callbacks[key](transfer.payload,
-                                                            transfer)
-                    del self.outstanding_requests[key]
-                    del self.outstanding_request_callbacks[key]
-                    del self.outstanding_request_timestamps[key]
-                    del self.outstanding_request_retries[key]
+                if transfer.is_response_to(self._outstanding_requests[key]):
+                    # Call the request's callback and remove it from the active list
+                    self._outstanding_request_callbacks[key](transfer.payload, transfer)
+                    del self._outstanding_requests[key]
+                    del self._outstanding_request_callbacks[key]
+                    del self._outstanding_request_timestamps[key]
                     break
-        elif not transfer.service_not_message or \
-                transfer.dest_node_id == self.node_id:
-            # This is a request, a unicast or a broadcast; look up the
-            # appropriate handler by data type ID
-            for handler in self.handlers:
+        elif not transfer.service_not_message or transfer.dest_node_id == self.node_id:
+            # This is a request, a unicast or a broadcast; look up the appropriate handler by data type ID
+            for handler in self._handlers:
                 if handler[0] == transfer.payload.type:
                     kwargs = handler[2] if len(handler) == 3 else {}
                     h = handler[1](transfer.payload, transfer, self, **kwargs)
                     h._execute()
 
     def _next_transfer_id(self, key):
-        transfer_id = self.next_transfer_ids[key]
-        self.next_transfer_ids[key] = (transfer_id + 1) & 0x1F
+        transfer_id = self._next_transfer_ids[key]
+        self._next_transfer_ids[key] = (transfer_id + 1) & 0x1F
         return transfer_id
 
-    def listen(self, device, baudrate=1000000, io_loop=None):
-        if device.startswith("/dev"):
-            self.can = driver.SLCAN(device, baudrate=baudrate)
-        else:
-            self.can = driver.SocketCAN(device)
+    def _send_node_status(self):
+        if self.node_id:
+            msg = uavcan.protocol.NodeStatus()
+            msg.uptime_sec = int(time.monotonic() - self.start_time_monotonic + 0.5)
+            msg.health = self.health
+            msg.mode = self.mode
+            msg.sub_mode = 0
+            msg.vendor_specific_status_code = self.vendor_specific_status_code
+            self.send_message(msg)
 
-        self.can.open()
+    def spin(self, timeout=None):
+        """Runs background processes until timeout expires.
+        Note that all processing is implemented in one thread.
+        :param timeout: The method will return once this amount of time expires.
+                        If None, the method will never return.
+                        If zero, the method will handle only those events that are ready, then return immediately.
+        """
+        deadline = (time.monotonic() + timeout) if timeout is not None else sys.float_info.max
 
-        # Send node status every 0.5 sec
-        self.start_time = time.time()
-        # TODO: make it easier to get constant values from UAVCAN types
-        self.health = uavcan.protocol.NodeStatus().HEALTH_OK
-        self.mode = uavcan.protocol.NodeStatus().MODE_OPERATIONAL
+        def execute_once():
+            next_event_at = self._poll_scheduler_and_get_remaining_time_to_next_deadline() or sys.float_info.max
 
-        if io_loop:
-            # Run asynchronously on a Tornado ioloop
-            import tornado.ioloop
+            read_timeout = min(next_event_at, deadline) - time.monotonic()
+            read_timeout = max(read_timeout, 0)
 
-            self.can.add_to_ioloop(io_loop, callback=self._recv_frame)
-            self.nodestatus_timer = tornado.ioloop.PeriodicCallback(
-                self.send_node_status,
-                NODE_STATUS_INVERVAL * 1000.0, io_loop=io_loop)
-            self.nodestatus_timer.start()
-        else:
-            # Run synchronously
-            last_status_t = time.time()
-            while True:
-                messages = self.can._recv()
+            frame = self._can_driver.receive(read_timeout)
+            if frame:
+                self._recv_frame(frame)
 
-                if messages:
-                    for message in messages:
-                        self._recv_frame(self.can, message)
-
-                if time.time() - last_status_t > NODE_STATUS_INVERVAL:
-                    self.send_node_status()
-                    last_status_t = time.time()
-
-    def send_node_status(self):
-        # Expire any requests more than one second old
-        requests = self.outstanding_requests.keys()
-        for key in requests:
-            if time.time() - self.outstanding_request_timestamps[key] > 1.0:
-                # Retry the request, or time it out if there are no retries
-                # remaining
-                if self.outstanding_request_retries[key]:
-                    self.outstanding_request_retries[key] -= 1
-                    self.outstanding_request_timestamps[key] = time.time()
-
-                    for frame in self.outstanding_requests[key].to_frames():
-                        self.can.send(frame.message_id, frame.bytes,
-                                      extended=True)
-                else:
-                    self.outstanding_request_callbacks[key](None, None)
-
-                    del self.outstanding_requests[key]
-                    del self.outstanding_request_callbacks[key]
-                    del self.outstanding_request_timestamps[key]
-                    del self.outstanding_request_retries[key]
-
-        # Send the node status message
-        status = uavcan.protocol.NodeStatus()
-        status.uptime_sec = int(time.time() - self.start_time)
-        status.health = self.health
-        status.mode = self.mode
-        status.sub_mode = 0
-        status.vendor_specific_status_code = 0
-        self.send_message(status)
+        execute_once()
+        while time.monotonic() < deadline:
+            execute_once()
 
     def send_request(self, payload, dest_node_id=None, callback=None):
-        transfer_id = self._next_transfer_id((payload.type.default_dtid,
-                                              dest_node_id))
-        transfer = transport.Transfer(
-            payload=payload,
-            source_node_id=self.node_id,
-            dest_node_id=dest_node_id,
-            transfer_id=transfer_id,
-            service_not_message=True,
-            request_not_response=True)
+        transfer_id = self._next_transfer_id((payload.type.default_dtid, dest_node_id))
+        transfer = transport.Transfer(payload=payload,
+                                      source_node_id=self.node_id,
+                                      dest_node_id=dest_node_id,
+                                      transfer_id=transfer_id,
+                                      service_not_message=True,
+                                      request_not_response=True)
 
         for frame in transfer.to_frames():
-            self.can.send(frame.message_id, frame.bytes, extended=True)
+            self._can_driver.send(frame.message_id, frame.bytes, extended=True)
 
         if callback:
-            self.outstanding_requests[transfer.key] = transfer
-            self.outstanding_request_callbacks[transfer.key] = callback
-            self.outstanding_request_timestamps[transfer.key] = time.time()
-            self.outstanding_request_retries[transfer.key] = 3
+            self._outstanding_requests[transfer.key] = transfer
+            self._outstanding_request_callbacks[transfer.key] = callback
+            self._outstanding_request_timestamps[transfer.key] = time.monotonic()
 
-        logging.debug(
-            "Node.send_request(dest_node_id={0:d}): sent {1!r}".format(
-            dest_node_id, payload))
+        logging.debug("Node.send_request(dest_node_id={0:d}): sent {1!r}".format(dest_node_id, payload))
 
     def send_message(self, payload):
+        if not self.node_id:
+            raise Exception('The node is configured in anonymous mode')  # TODO: use custom exception class
+
         transfer_id = self._next_transfer_id(payload.type.default_dtid)
-        transfer = transport.Transfer(
-            payload=payload,
-            source_node_id=self.node_id,
-            transfer_id=transfer_id,
-            service_not_message=False)
+        transfer = transport.Transfer(payload=payload,
+                                      source_node_id=self.node_id,
+                                      transfer_id=transfer_id,
+                                      service_not_message=False)
 
         for frame in transfer.to_frames():
-            self.can.send(frame.message_id, frame.bytes, extended=True)
+            self._can_driver.send(frame.message_id, frame.bytes, extended=True)
 
         logging.debug("Node.send_message(): sent {0!r}".format(payload))
+
+    def close(self):
+        self._can_driver.close()
+
+
+def make_node(can_device_name, **kwargs):
+    """Constructs a node instance with specified CAN device.
+    :param can_device_name: CAN device name, e.g. "/dev/ttyACM0", "COM9", "can0".
+    :param kwargs: These arguments will be supplied to the CAN driver factory and to the node constructor.
+    """
+    can = driver.make_driver(can_device_name, **kwargs)
+    return Node(can, **kwargs)
 
 
 class Monitor(object):
@@ -209,8 +261,7 @@ class Service(Monitor):
     def __init__(self, *args, **kwargs):
         super(Service, self).__init__(*args, **kwargs)
         self.request = self.message
-        self.response = transport.CompoundValue(self.request.type, tao=True,
-                                                mode="response")
+        self.response = transport.CompoundValue(self.request.type, tao=True, mode="response")
 
     def _execute(self):
         result = self.on_request()
@@ -229,9 +280,8 @@ class Service(Monitor):
             self.node.can.send(frame.message_id, frame.bytes,
                                extended=True)
 
-        logging.debug(
-            "ServiceHandler._execute(dest_node_id={0:d}): sent {1!r}".format(
-            self.transfer.source_node_id, self.response))
+        logging.debug("ServiceHandler._execute(dest_node_id={0:d}): sent {1!r}"
+                      .format(self.transfer.source_node_id, self.response))
 
     def on_request(self):
         pass

--- a/uavcan/node.py
+++ b/uavcan/node.py
@@ -405,7 +405,7 @@ class Service(object):
         self.request = event.request
         self.transfer = event.transfer
         self.node = event.node
-        self.response = transport.CompoundValue(self.request.type, _mode="response")
+        self.response = self.request.type.Response()
 
     def on_request(self):
         pass

--- a/uavcan/services/__init__.py
+++ b/uavcan/services/__init__.py
@@ -15,9 +15,8 @@ class FileGetInfoService(uavcan.node.Service):
         self.base_path = kwargs.get("path")
 
     def on_request(self):
-        logger.debug("[#{0:03d}:uavcan.protocol.file.GetInfo] {1!r}".format(
-                      self.transfer.source_node_id,
-                      self.request.path.path.decode()))
+        logger.debug("[#{0:03d}:uavcan.protocol.file.GetInfo] {1!r}"
+                     .format(self.transfer.source_node_id, self.request.path.path.decode()))
         try:
             vpath = self.request.path.path.decode()
             with open(os.path.join(self.base_path, vpath), "rb") as fw:
@@ -43,10 +42,8 @@ class FileReadService(uavcan.node.Service):
         self.base_path = kwargs.get("path")
 
     def on_request(self):
-        logger.debug(("[#{0:03d}:uavcan.protocol.file.Read] {1!r} @ " +
-                       "offset {2:d}").format(self.transfer.source_node_id,
-                                              self.request.path.path.decode(),
-                                              self.request.offset))
+        logger.debug("[#{0:03d}:uavcan.protocol.file.Read] {1!r} @ offset {2:d}"
+                     .format(self.transfer.source_node_id, self.request.path.path.decode(), self.request.offset))
         try:
             vpath = self.request.path.path.decode()
             with open(os.path.join(self.base_path, vpath), "rb") as fw:

--- a/uavcan/services/__init__.py
+++ b/uavcan/services/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import division, absolute_import, print_function, unicode_literals
 import os
 import logging
 

--- a/uavcan/services/__init__.py
+++ b/uavcan/services/__init__.py
@@ -1,9 +1,12 @@
 from __future__ import division, absolute_import, print_function, unicode_literals
 import os
-import logging
+from logging import getLogger
 
 import uavcan
 import uavcan.node
+
+
+logger = getLogger(__name__)
 
 
 class FileGetInfoService(uavcan.node.Service):
@@ -12,7 +15,7 @@ class FileGetInfoService(uavcan.node.Service):
         self.base_path = kwargs.get("path")
 
     def on_request(self):
-        logging.debug("[#{0:03d}:uavcan.protocol.file.GetInfo] {1!r}".format(
+        logger.debug("[#{0:03d}:uavcan.protocol.file.GetInfo] {1!r}".format(
                       self.transfer.source_node_id,
                       self.request.path.path.decode()))
         try:
@@ -27,7 +30,7 @@ class FileGetInfoService(uavcan.node.Service):
                     (self.response.entry_type.FLAG_FILE |
                      self.response.entry_type.FLAG_READABLE)
         except Exception:
-            logging.exception("[#{0:03d}:uavcan.protocol.file.GetInfo] error")
+            logger.exception("[#{0:03d}:uavcan.protocol.file.GetInfo] error")
             self.response.error.value = self.response.error.UNKNOWN_ERROR
             self.response.size = 0
             self.response.crc64 = 0
@@ -40,7 +43,7 @@ class FileReadService(uavcan.node.Service):
         self.base_path = kwargs.get("path")
 
     def on_request(self):
-        logging.debug(("[#{0:03d}:uavcan.protocol.file.Read] {1!r} @ " +
+        logger.debug(("[#{0:03d}:uavcan.protocol.file.Read] {1!r} @ " +
                        "offset {2:d}").format(self.transfer.source_node_id,
                                               self.request.path.path.decode(),
                                               self.request.offset))
@@ -52,5 +55,5 @@ class FileReadService(uavcan.node.Service):
                     self.response.data.append(ord(byte))
                 self.response.error.value = self.response.error.OK
         except Exception:
-            logging.exception("[#{0:03d}:uavcan.protocol.file.Read] error")
+            logger.exception("[#{0:03d}:uavcan.protocol.file.Read] error")
             self.response.error.value = self.response.error.UNKNOWN_ERROR

--- a/uavcan/services/__init__.py
+++ b/uavcan/services/__init__.py
@@ -1,3 +1,12 @@
+#
+# Copyright (C) 2014-2015  UAVCAN Development Team  <uavcan.org>
+#
+# This software is distributed under the terms of the MIT License.
+#
+# Author: Ben Dyer <ben_dyer@mac.com>
+#         Pavel Kirienko <pavel.kirienko@zubax.com>
+#
+
 from __future__ import division, absolute_import, print_function, unicode_literals
 import os
 from logging import getLogger

--- a/uavcan/transport.py
+++ b/uavcan/transport.py
@@ -342,6 +342,8 @@ class CompoundValue(BaseValue):
             else:
                 raise ValueError("mode must be either 'request' or 'response' for service types")
         else:
+            if self.mode != None:
+                raise ValueError("mode is not applicable for message types")
             source_fields = self.type.fields
             source_constants = self.type.constants
             is_union = self.type.union

--- a/uavcan/transport.py
+++ b/uavcan/transport.py
@@ -363,6 +363,11 @@ class CompoundValue(BaseValue):
             elif isinstance(field.type, dsdl.parser.CompoundType):
                 self.fields[field.name] = CompoundValue(field.type, tao=atao)
 
+        for name, value in kwargs.items():
+            if name.startswith('_'):
+                raise NameError('%r is not a valid field name' % name)
+            setattr(self, name, value)
+
     def __repr__(self):
         if self.is_union:
             field = self.union_field or self.fields.keys()[0]

--- a/uavcan/transport.py
+++ b/uavcan/transport.py
@@ -136,8 +136,8 @@ class Void(object):
 
 
 class BaseValue(object):
-    def __init__(self, uavcan_type, *args, **kwargs):
-        self.type = uavcan_type
+    def __init__(self, _uavcan_type, *args, **kwargs):
+        self.type = _uavcan_type
         self._bits = None
 
     def unpack(self, stream):
@@ -204,10 +204,10 @@ class PrimitiveValue(BaseValue):
 
 
 class ArrayValue(BaseValue, collections.MutableSequence):
-    def __init__(self, uavcan_type, tao=False, *args, **kwargs):
-        super(ArrayValue, self).__init__(uavcan_type, *args, **kwargs)
+    def __init__(self, _uavcan_type, _tao=False, *args, **kwargs):
+        super(ArrayValue, self).__init__(_uavcan_type, *args, **kwargs)
         value_bitlen = getattr(self.type.value_type, "bitlen", 0)
-        self._tao = tao if value_bitlen >= 8 else False
+        self._tao = _tao if value_bitlen >= 8 else False
 
         if isinstance(self.type.value_type, dsdl.parser.PrimitiveType):
             self.__item_ctor = functools.partial(PrimitiveValue, self.type.value_type)
@@ -319,11 +319,11 @@ class ArrayValue(BaseValue, collections.MutableSequence):
 
 
 class CompoundValue(BaseValue):
-    def __init__(self, uavcan_type, mode=None, tao=False, *args, **kwargs):
+    def __init__(self, _uavcan_type, _mode=None, _tao=False, *args, **kwargs):
         self.__dict__["fields"] = collections.OrderedDict()
         self.__dict__["constants"] = {}
-        super(CompoundValue, self).__init__(uavcan_type, *args, **kwargs)
-        self.mode = mode
+        super(CompoundValue, self).__init__(_uavcan_type, *args, **kwargs)
+        self.mode = _mode
         self.data_type_id = self.type.default_dtid
         self.crc_base = ""
 
@@ -353,7 +353,7 @@ class CompoundValue(BaseValue):
             self.constants[constant.name] = constant.value
 
         for idx, field in enumerate(source_fields):
-            atao = field is source_fields[-1] and tao
+            atao = field is source_fields[-1] and _tao
             if isinstance(field.type, dsdl.parser.VoidType):
                 self.fields["_void_{0}".format(idx)] = Void(field.type.bitlen)
             elif isinstance(field.type, dsdl.parser.PrimitiveType):
@@ -428,7 +428,7 @@ class CompoundValue(BaseValue):
 
 
 class Frame(object):
-    def __init__(self, message_id, bytes):
+    def __init__(self, message_id, bytes):  # @ReservedAssignment
         self.message_id = message_id
         self.bytes = bytearray(bytes)
 
@@ -607,7 +607,7 @@ class Transfer(object):
         self.data_type_crc = datatype.base_crc
 
         if self.service_not_message:
-            self.payload = datatype(mode="request" if self.request_not_response else "response")
+            self.payload = datatype(_mode="request" if self.request_not_response else "response")
         else:
             self.payload = datatype()
         self.payload.unpack(bits_from_bytes(payload_bytes))

--- a/uavcan/transport.py
+++ b/uavcan/transport.py
@@ -371,7 +371,7 @@ class CompoundValue(BaseValue):
 
     def __repr__(self):
         if self.is_union:
-            field = self.union_field or self.fields.keys()[0]
+            field = self.union_field or list(self.fields.keys())[0]
             fields = "{0}={1!r}".format(field, self.fields[field])
         else:
             fields = ", ".join("{0}={1!r}".format(f, v) for f, v in self.fields.items() if not f.startswith("_void_"))
@@ -414,7 +414,7 @@ class CompoundValue(BaseValue):
     def unpack(self, stream):
         if self.is_union:
             tag_len = union_tag_len(self.fields)
-            self.union_field = self.fields.keys()[int(stream[0:tag_len], 2)]
+            self.union_field = list(self.fields.keys())[int(stream[0:tag_len], 2)]
             stream = self.fields[self.union_field].unpack(stream[tag_len:])
         else:
             for field in self.fields.values():

--- a/uavcan/transport.py
+++ b/uavcan/transport.py
@@ -1,5 +1,6 @@
 #encoding=utf-8
 
+from __future__ import division, absolute_import, print_function, unicode_literals
 import sys
 import time
 import math

--- a/uavcan/transport.py
+++ b/uavcan/transport.py
@@ -431,9 +431,11 @@ class CompoundValue(BaseValue):
 
 
 class Frame(object):
-    def __init__(self, message_id, bytes):  # @ReservedAssignment
+    def __init__(self, message_id, bytes, ts_monotonic=None, ts_real=None):  # @ReservedAssignment
         self.message_id = message_id
         self.bytes = bytearray(bytes)
+        self.ts_monotonic = ts_monotonic
+        self.ts_real = ts_real
 
     @property
     def transfer_key(self):
@@ -562,6 +564,10 @@ class Transfer(object):
         return out_frames
 
     def from_frames(self, frames):
+        # Initialize transfer timestamps from the first frame
+        self.ts_monotonic = frames[0].ts_monotonic
+        self.ts_real = frames[0].ts_real
+
         # Validate the flags in the tail byte
         expected_toggle = 0
         expected_transfer_id = frames[0].bytes[-1] & 0x1F

--- a/uavcan/transport.py
+++ b/uavcan/transport.py
@@ -3,9 +3,7 @@
 import sys
 import time
 import math
-import ctypes
 import struct
-import logging
 import binascii
 import functools
 import collections

--- a/uavcan/transport.py
+++ b/uavcan/transport.py
@@ -329,25 +329,24 @@ class CompoundValue(BaseValue):
         self.__dict__["fields"] = collections.OrderedDict()
         self.__dict__["constants"] = {}
         super(CompoundValue, self).__init__(_uavcan_type, *args, **kwargs)
-        self.mode = _mode
         self.data_type_id = self.type.default_dtid
 
         source_fields = None
         source_constants = None
         is_union = False
         if self.type.kind == dsdl.parser.CompoundType.KIND_SERVICE:
-            if self.mode == "request":
+            if _mode == "request":
                 source_fields = self.type.request_fields
                 source_constants = self.type.request_constants
                 is_union = self.type.request_union
-            elif self.mode == "response":
+            elif _mode == "response":
                 source_fields = self.type.response_fields
                 source_constants = self.type.response_constants
                 is_union = self.type.response_union
             else:
                 raise ValueError("mode must be either 'request' or 'response' for service types")
         else:
-            if self.mode != None:
+            if _mode != None:
                 raise ValueError("mode is not applicable for message types")
             source_fields = self.type.fields
             source_constants = self.type.constants

--- a/uavcan/transport.py
+++ b/uavcan/transport.py
@@ -1,4 +1,4 @@
-#encoding=utf-8
+# encoding=utf-8
 
 from __future__ import division, absolute_import, print_function, unicode_literals
 import sys
@@ -26,7 +26,7 @@ def bits_from_bytes(s):
 
 
 def bytes_from_bits(s):
-    return bytearray(int(s[i:i+8], 2) for i in range(0, len(s), 8))
+    return bytearray(int(s[i:i + 8], 2) for i in range(0, len(s), 8))
 
 
 def be_from_le_bits(s, bitlen):
@@ -48,7 +48,7 @@ def le_from_be_bits(s, bitlen):
 
 
 def format_bits(s):
-    return " ".join(s[i:i+8] for i in range(0, len(s), 8))
+    return " ".join(s[i:i + 8] for i in range(0, len(s), 8))
 
 
 def union_tag_len(x):
@@ -61,8 +61,8 @@ def f16_from_f32(float32):
     F16_EXPONENT_SHIFT = 10
     F16_EXPONENT_BIAS = 15
     F16_MANTISSA_BITS = 0x3ff
-    F16_MANTISSA_SHIFT =  (23 - F16_EXPONENT_SHIFT)
-    F16_MAX_EXPONENT =  (F16_EXPONENT_BITS << F16_EXPONENT_SHIFT)
+    F16_MANTISSA_SHIFT = (23 - F16_EXPONENT_SHIFT)
+    F16_MAX_EXPONENT = (F16_EXPONENT_BITS << F16_EXPONENT_SHIFT)
 
     a = struct.pack('>f', float32)
     b = binascii.hexlify(a)
@@ -217,7 +217,7 @@ class ArrayValue(BaseValue, collections.MutableSequence):
             self.__item_ctor = functools.partial(CompoundValue, self.type.value_type)
 
         if self.type.mode == dsdl.parser.ArrayType.MODE_STATIC:
-            self.__items = list(self.__item_ctor() for i in range(self.type.max_size))
+            self.__items = list(self.__item_ctor() for _ in range(self.type.max_size))
         else:
             self.__items = []
 
@@ -400,8 +400,7 @@ class CompoundValue(BaseValue):
                 else:
                     self.union_field = attr
 
-            if isinstance(self.fields[attr].type,
-                            dsdl.parser.PrimitiveType):
+            if isinstance(self.fields[attr].type, dsdl.parser.PrimitiveType):
                 self.fields[attr].value = value
             else:
                 raise AttributeError(attr + " cannot be set directly")

--- a/uavcan/transport.py
+++ b/uavcan/transport.py
@@ -1,4 +1,11 @@
-# encoding=utf-8
+#
+# Copyright (C) 2014-2015  UAVCAN Development Team  <uavcan.org>
+#
+# This software is distributed under the terms of the MIT License.
+#
+# Author: Ben Dyer <ben_dyer@mac.com>
+#         Pavel Kirienko <pavel.kirienko@zubax.com>
+#
 
 from __future__ import division, absolute_import, print_function, unicode_literals
 import sys

--- a/uavcan/transport.py
+++ b/uavcan/transport.py
@@ -324,7 +324,6 @@ class CompoundValue(BaseValue):
         super(CompoundValue, self).__init__(_uavcan_type, *args, **kwargs)
         self.mode = _mode
         self.data_type_id = self.type.default_dtid
-        self.crc_base = ""
 
         source_fields = None
         source_constants = None


### PR DESCRIPTION
This is still a work-in-progress.

@bendyer I'd like to ask a few questions concerning your implementation before I continue.

* [`_instantiate()` method](https://github.com/UAVCAN/pyuavcan/blob/master/uavcan/__init__.py#L93-L99). It is initialized in `load_dsdl()`, but it is not called from anywhere. Why do we need it?

* Field initialization via the constructor of `CompoundValue` seems to be intended, but not implemented. Is my understanding correct that the proper way of adding this feature would be adding necessary `setattr()` calls [here](https://github.com/UAVCAN/pyuavcan/blob/master/uavcan/transport.py#L376)? E.g.:

```python
for name, value in kwargs.items():
    setattr(self, name, value)
```

* The logic for handling incoming messages/requests/responses seems overengineered. I'm talking about `node.Monitor` and `node.Service`. I suggest to replace that with more Pythonic-looking callables, something along the lines of:

```python
def handle_service_request(request)
    response = process(request)
    return response

node.add_handler(MyServiceType, handle_service_request)
node.add_handler(MyMessageType, print)  # Print received messages
```

The proposed approach is also compatible with the existing interface-based approach.

---

It would be great if you could also review my other changes. They are not finished yet, but any feedback would be welcome. I am particularly interested in your opinion concerning the new `spin()` method instead of `listen()` (see my email from Nov 19):

```python
import uavcan
n = uavcan.make_node('/dev/ttyACM0', node_id=12, bitrate=100000, baudrate=115200)
n.periodic(1, lambda: n.send_message(uavcan.protocol.debug.KeyValue()))
n.spin(60)
print('Exit after 1 minute')
```

I had to temporarily drop the support for Tornado because it was getting in the way of refactoring. We can bring it back later if you still need it.