### PR TITLE
Fix a bug on 32bit Python 2

### DIFF
--- a/uavcan/transport.py
+++ b/uavcan/transport.py
@@ -142,12 +142,12 @@ class Float32IntegerUnion(object):
 
     @property
     def u(self):
-        return struct.unpack("=L", self._bytes)[0]
+        return struct.unpack("=I", self._bytes)[0]
 
     @u.setter
     def u(self, value):
-        assert isinstance(value, int)
-        self._bytes = struct.pack("=L", value)
+        assert isinstance(value, int) or isinstance(value, long)
+        self._bytes = struct.pack("=I", value)
 
 
 def f16_from_f32(float32):


### PR DESCRIPTION
When running current Pyuavcan on a beaglebone black I got the following error:

```
======================================================================
FAIL: test_basic (test.test_transport.TestFloats)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_transport.py", line 642, in test_basic
    a.value = float('-inf')
  File "uavcan/transport.py", line 296, in value
    int_value = f16_from_f32(new_value)
  File "uavcan/transport.py", line 172, in f16_from_f32
    inval.u = inval.u ^ sign
  File "uavcan/transport.py", line 153, in u
    assert isinstance(value, int)
AssertionError
```

after a bit of debugging it appears to be related to how Python2 handles integers (the problem is not present in python3). This PR fixes the issues and all tests still pass, both on python 2 & 3.