### PR TITLE
Default folder to define/symlink custom uavcan types

### DIFF
--- a/uavcan/__init__.py
+++ b/uavcan/__init__.py
@@ -120,10 +120,10 @@ def load_dsdl(*paths, **args):
         if not args.get("exclude_dist", None):
             dsdl_path = pkg_resources.resource_filename(__name__, "dsdl_files")  # @UndefinedVariable
             paths = [os.path.join(dsdl_path, "uavcan")] + paths
-            custom_path = os.path.join(os.path.expanduser("~"),"uavcan_custom_types")
+            custom_path = os.path.join(os.path.expanduser("~"), "uavcan_vendor_specific_types")
             if os.path.isdir(custom_path):
-                paths = [f for f in [os.path.join(custom_path,f) for f in os.listdir(custom_path)] 
-                            if os.path.isdir(f)] + paths
+                paths += [f for f in [os.path.join(custom_path, f) for f in os.listdir(custom_path)]
+                          if os.path.isdir(f)]
     except Exception:
         pass
 

--- a/uavcan/__init__.py
+++ b/uavcan/__init__.py
@@ -120,6 +120,10 @@ def load_dsdl(*paths, **args):
         if not args.get("exclude_dist", None):
             dsdl_path = pkg_resources.resource_filename(__name__, "dsdl_files")  # @UndefinedVariable
             paths = [os.path.join(dsdl_path, "uavcan")] + paths
+            custom_path = os.path.join(os.path.expanduser("~"),"uavcan_custom_types")
+            if os.path.isdir(custom_path):
+                paths = [f for f in [os.path.join(custom_path,f) for f in os.listdir(custom_path)] 
+                            if os.path.isdir(f)] + paths
     except Exception:
         pass
 


### PR DESCRIPTION
As discussed on gitter. patch adds all folders found in ~/uavcan_custom_types to the list
of known Datatypes on loading the Module

A dialog in the Gui tool could easily symlink the folder containing the a Users datatypes to the uavcan_custom_types folder. 