### PR TITLE
Python 2.7 compatabilty for byte arrays

### DIFF
--- a/uavcan/app/dynamic_node_id.py
+++ b/uavcan/app/dynamic_node_id.py
@@ -19,7 +19,7 @@ logger = getLogger(__name__)
 
 
 def _unique_id_to_string(uid):
-    return ' '.join(['%02X' % x for x in uid]) if uid else None
+    return ' '.join(['%02X' % x for x in bytearray(uid)]) if uid else None
 
 
 class CentralizedServer(object):

--- a/uavcan/app/file_server.py
+++ b/uavcan/app/file_server.py
@@ -90,7 +90,7 @@ class FileServer(object):
                 f.seek(e.request.offset)
                 resp = uavcan.protocol.file.Read.Response()
                 read_size = uavcan.get_uavcan_data_type(uavcan.get_fields(resp)['data']).max_size
-                resp.data = f.read(read_size)
+                resp.data = bytearray(f.read(read_size))
                 resp.error.value = resp.error.OK
         except Exception:
             logger.exception("[#{0:03d}:uavcan.protocol.file.Read] error")


### PR DESCRIPTION
Explicitly convert byte arrays to `bytearray` type to allow item iteration in python 2.7.