### PR TITLE
slcan driver: increase receive buffer size in non-Mac OS

### DIFF
--- a/uavcan/driver/slcan.py
+++ b/uavcan/driver/slcan.py
@@ -47,7 +47,11 @@ except AttributeError:
 #
 # Constants and defaults
 #
-RX_QUEUE_SIZE = 32767   # http://stackoverflow.com/questions/5900985/multiprocessing-queue-maxsize-limit-is-32767
+if 'darwin' in sys.platform:
+    RX_QUEUE_SIZE = 32767   # http://stackoverflow.com/questions/5900985/multiprocessing-queue-maxsize-limit-is-32767
+else:
+    RX_QUEUE_SIZE = 1000000
+
 TX_QUEUE_SIZE = 1000
 
 TIMESTAMP_OVERFLOW_PERIOD = 60          # Defined by SLCAN protocol


### PR DESCRIPTION
As requested by @pavel-kirienko in https://github.com/ArduPilot/ardupilot/issues/8166#issuecomment-389222002, this patch increases the slcan driver receive buffer to one million in non-Mac OS.

As explained in that issue, the buffer is too small when the bus has a high number of messages.

**This was only tested in Ubuntu 16.04**