### PR TITLE
Python 3.7 compatibility

### DIFF
--- a/uavcan/transport.py
+++ b/uavcan/transport.py
@@ -124,7 +124,10 @@ def enum_mark_last(iterable, start=0):
     """
     it = iter(iterable)
     count = start
-    last = next(it)
+    try:
+        last = next(it)
+    except StopIteration:
+        return
     for val in it:
         yield count, False, last
         last = val


### PR DESCRIPTION
Python 3.7 / PEP479 

This just catches StopIteration in `transport.py` and seems to be all that is necessary for Python 3.7 support.