### PR TITLE
Re-raise callback exceptions if asked to

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
-install: pip install .
+install:
+  - pip install .
+  - pip install mock
 script: python -m unittest discover test
 deploy:
   provider: pypi

--- a/test/test_node.py
+++ b/test/test_node.py
@@ -8,7 +8,11 @@
 #
 
 import unittest
-from unittest.mock import Mock, ANY
+try:
+    from unittest.mock import Mock, ANY
+except ImportError:
+    from mock import Mock, ANY
+
 import uavcan
 from uavcan.node import Node
 import uavcan.transport as transport

--- a/test/test_node.py
+++ b/test/test_node.py
@@ -8,7 +8,7 @@
 #
 
 import unittest
-from unittest.mock import Mock
+from unittest.mock import Mock, ANY
 import uavcan
 from uavcan.node import Node
 import uavcan.transport as transport
@@ -65,6 +65,18 @@ class HandlerExceptionHandling(unittest.TestCase):
 
         with self.assertRaises(RuntimeError):
             self._spin()
+
+    def test_second_handler_is_called_after_first_one_raises(self):
+        mock_cb = Mock(return_value=None)
+        self.node = Node(self.driver)
+        self.node.add_handler(uavcan.protocol.debug.KeyValue,
+                              self._raise_callback)
+        self.node.add_handler(uavcan.protocol.debug.KeyValue,
+                              mock_cb)
+
+        self._spin()
+        mock_cb.assert_any_call(ANY)
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This commit fixes issue #45, by adding a flag to the spin method. It
allows the user to catch exceptions thrown from messages handler. This
is useful during debugging, so that thrown exceptions can be caught by
debuggers.

Not yet tested on a real project as I don't have hardware with me. Will report testing result ASAP.