### PR TITLE
Add cache to compute_signature

### DIFF
--- a/uavcan/dsdl/signature.py
+++ b/uavcan/dsdl/signature.py
@@ -8,6 +8,7 @@
 #
 
 from __future__ import division, absolute_import, print_function, unicode_literals
+import functools
 
 #
 # CRC-64-WE
@@ -58,6 +59,7 @@ class Signature:
         return (self._crc & Signature.MASK64) ^ Signature.MASK64
 
 
+@functools.lru_cache()
 def compute_signature(data):
     '''
     One-shot signature computation for ASCII string or bytes.


### PR DESCRIPTION
compute_signature creates a huge load on slow hardware (e.g. raspberry
pi). Using the functools lru cache removes most of that. Still, a higher
level cache that gets reused between instances of the same data type
would be more effective.
In practice, this commit is the difference between usable and unusable
for my raspberry pi logging some stuff with ~20 packets per second.

Big downside:
`functools.lru_cache` is Python 3.2+ only!