### PR TITLE
Define long in Python 3

### DIFF
--- a/uavcan/transport.py
+++ b/uavcan/transport.py
@@ -21,6 +21,11 @@ import uavcan.dsdl as dsdl
 import uavcan.dsdl.common as common
 
 
+try:
+    long        # Python 2
+except NameError:
+    long = int  # Python 3
+
 if sys.version_info[0] < 3:
     bchr = chr
 else:
@@ -169,7 +174,7 @@ class Float32IntegerUnion(object):
 
     @u.setter
     def u(self, value):
-        assert isinstance(value, int) or isinstance(value, long)
+        assert isinstance(value, (int, long))
         self._bytes = struct.pack("=I", value)
 
 


### PR DESCRIPTION
__long__ was removed in Python 3 because all __int__ are of infinite precision.

@pavel-kirienko Your review please?

[flake8](http://flake8.pycqa.org) testing of https://github.com/UAVCAN/pyuavcan on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./uavcan/transport.py:172:60: F821 undefined name 'long'
        assert isinstance(value, int) or isinstance(value, long)
                                                           ^
1     F821 undefined name 'long'
1
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree