### PR TITLE
Travis CI: Drop Python 3.3 and add Python 3.6 and 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,14 @@
-sudo: false
 language: python
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
+matrix:
+  include:
+    - python: "3.7"
+      dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)
 install:
-  - pip install .
   - pip install mock
 script: python -m unittest discover test
 deploy:


### PR DESCRIPTION
Python 3.3 was end of life years ago and 3.4 end of life is in less than 60 days... https://devguide.python.org/#branchstatus

Also, [Travis are now recommending removing the __sudo__ tag](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).