### PR TITLE
Improve python-can driver

### DIFF
--- a/uavcan/driver/__init__.py
+++ b/uavcan/driver/__init__.py
@@ -11,12 +11,18 @@ from __future__ import division, absolute_import, print_function, unicode_litera
 import sys
 from .slcan import SLCAN
 from .common import DriverError, CANFrame
-from .python_can import PythonCan
 
 if sys.platform.startswith('linux'):
     from .socketcan import SocketCAN
 else:
     SocketCAN = None
+
+try:
+    import can
+except ImportError:
+    PythonCAN = None
+else:
+    from .python_can import PythonCAN
 
 __all__ = ['make_driver', 'DriverError', 'CANFrame']
 
@@ -29,12 +35,11 @@ def make_driver(device_name, **kwargs):
     """
     windows_com_port = device_name.replace('\\', '').replace('.', '').lower().startswith('com')
     unix_tty = device_name.startswith('/dev/')
-    pythoncan = device_name.startswith('pythoncan')
 
     if windows_com_port or unix_tty:
         return SLCAN(device_name, **kwargs)
-    elif pythoncan:
-        return PythonCan()
+    elif PythonCAN is not None:
+        return PythonCAN(device_name, **kwargs)
     elif SocketCAN is not None:
         return SocketCAN(device_name, **kwargs)
     else:

--- a/uavcan/driver/__init__.py
+++ b/uavcan/driver/__init__.py
@@ -19,10 +19,9 @@ else:
 
 try:
     import can
+    from .python_can import PythonCAN
 except ImportError:
     PythonCAN = None
-else:
-    from .python_can import PythonCAN
 
 __all__ = ['make_driver', 'DriverError', 'CANFrame']
 

--- a/uavcan/driver/__init__.py
+++ b/uavcan/driver/__init__.py
@@ -9,6 +9,7 @@
 
 from __future__ import division, absolute_import, print_function, unicode_literals
 import sys
+from .python_can import PythonCAN
 from .slcan import SLCAN
 from .common import DriverError, CANFrame
 
@@ -16,12 +17,6 @@ if sys.platform.startswith('linux'):
     from .socketcan import SocketCAN
 else:
     SocketCAN = None
-
-try:
-    import can
-    from .python_can import PythonCAN
-except ImportError:
-    PythonCAN = None
 
 __all__ = ['make_driver', 'DriverError', 'CANFrame']
 

--- a/uavcan/driver/python_can.py
+++ b/uavcan/driver/python_can.py
@@ -24,28 +24,20 @@ except ImportError:
 
 logger = getLogger(__name__)
 
-try:
-    import can
-except ImportError:
-    logger.info("no module 'can' available, please install python-can")
-    can = None
+import can
 
-
-class PythonCan(AbstractDriver):
+class PythonCAN(AbstractDriver):
     TX_QUEUE_SIZE = 1000
 
-    def __init__(self):
-        super(PythonCan, self).__init__()
-
-        if can is None:
-            logger.error("To use this driver, make sure the module python-can is installed")
-            raise ValueError("python-can must be installed.")
+    def __init__(self, channel, **_extras):
+        super(PythonCAN, self).__init__()
 
         try:
-            self._bus = can.interface.Bus()
+            if channel is None:
+                self._bus = can.interface.Bus() # get bus from environment's config file
+            else:
+                self._bus = can.interface.Bus(channel=channel, bustype=_extras['bustype'], bitrate=_extras['bitrate'])
         except Exception as ex:
-            logger.info("Please make sure you have a valid can.ini file located in the current working directory.")
-            logger.info("See also: https://python-can.readthedocs.io/en/master/configuration.html#configuration-file")
             logger.exception("Could not instantiate a python-can driver")
             raise
 

--- a/uavcan/driver/python_can.py
+++ b/uavcan/driver/python_can.py
@@ -24,132 +24,135 @@ except ImportError:
 
 logger = getLogger(__name__)
 
-import can
+try:
+    import can
+except ImportError:
+    PythonCAN = None
+else:
+    class PythonCAN(AbstractDriver):
+        TX_QUEUE_SIZE = 1000
 
-class PythonCAN(AbstractDriver):
-    TX_QUEUE_SIZE = 1000
-
-    def __init__(self, channel, **_extras):
-        super(PythonCAN, self).__init__()
-
-        try:
-            if channel is None:
-                self._bus = can.interface.Bus() # get bus from environment's config file
-            else:
-                self._bus = can.interface.Bus(channel=channel, bustype=_extras['bustype'], bitrate=_extras['bitrate'])
-        except Exception as ex:
-            logger.exception("Could not instantiate a python-can driver")
-            raise
-
-        self._writer_thread_should_stop = False
-        self._write_queue = queue.Queue(self.TX_QUEUE_SIZE)
-        self._write_feedback_queue = queue.Queue()
-
-        self._writer_thread = threading.Thread(
-            target=self._writer_thread_loop, name="pythoncan_writer"
-        )
-        self._writer_thread.daemon = True
-        self._writer_thread.start()
-
-        ppm = lambda x: x / 1e6
-        milliseconds = lambda x: x * 1e-3
-
-        # We're using this thing to estimate the difference between monotonic and real clocks
-        # See http://stackoverflow.com/questions/35426864 (at the time of writing the question was unanswered)
-        self._mono_to_real_estimator = TimestampEstimator(
-            max_rate_error=ppm(100),
-            fixed_delay=milliseconds(0.001),
-            max_phase_error_to_resync=milliseconds(50),
-        )
-
-    def _convert_real_to_monotonic(self, value):
-        mono = time.monotonic()  # est_real is the best guess about real timestamp here
-        real = time.time()
-        est_real = self._mono_to_real_estimator.update(mono, real)
-        mono_to_real_offset = est_real - mono
-        return value - mono_to_real_offset
-
-    def _writer_thread_loop(self):
-        while not self._writer_thread_should_stop:
-            try:
-                frame = self._write_queue.get(timeout=0.1)
-            except queue.Empty:
-                continue
+        def __init__(self, channel, **_extras):
+            super(PythonCAN, self).__init__()
 
             try:
-                while not self._writer_thread_should_stop:
-                    try:
-                        msg = can.Message(
-                            arbitration_id=frame.id,
-                            extended_id=frame.extended,
-                            dlc=len(frame.data),
-                            data=list(frame.data),
-                        )
-                        self._bus.send(msg)
-                        self._bus.flush_tx_buffer()
-
-                        frame.ts_monotonic = time.monotonic()
-                        frame.ts_real = time.time()
-                        self._write_feedback_queue.put(frame)
-                    except OSError as ex:
-                        if ex.errno == errno.ENOBUFS:
-                            time.sleep(0.0002)
-                        else:
-                            raise
-                    else:
-                        break
+                if channel is None:
+                    self._bus = can.interface.Bus() # get bus from environment's config file
+                else:
+                    self._bus = can.interface.Bus(channel=channel, bustype=_extras['bustype'], bitrate=_extras['bitrate'])
             except Exception as ex:
-                self._write_feedback_queue.put(ex)
+                logger.exception("Could not instantiate a python-can driver")
+                raise
 
-    def _check_write_feedback(self):
-        try:
-            item = self._write_feedback_queue.get_nowait()
-        except queue.Empty:
-            return
+            self._writer_thread_should_stop = False
+            self._write_queue = queue.Queue(self.TX_QUEUE_SIZE)
+            self._write_feedback_queue = queue.Queue()
 
-        if isinstance(item, Exception):
-            raise item
+            self._writer_thread = threading.Thread(
+                target=self._writer_thread_loop, name="pythoncan_writer"
+            )
+            self._writer_thread.daemon = True
+            self._writer_thread.start()
 
-        if isinstance(item, CANFrame):
-            self._tx_hook(item)
-        else:
-            raise DriverError("Unexpected item in write feedback queue: %r" % item)
+            ppm = lambda x: x / 1e6
+            milliseconds = lambda x: x * 1e-3
 
-    def close(self):
-        self._writer_thread_should_stop = True
-        self._writer_thread.join()
-        self._bus.shutdown()
+            # We're using this thing to estimate the difference between monotonic and real clocks
+            # See http://stackoverflow.com/questions/35426864 (at the time of writing the question was unanswered)
+            self._mono_to_real_estimator = TimestampEstimator(
+                max_rate_error=ppm(100),
+                fixed_delay=milliseconds(0.001),
+                max_phase_error_to_resync=milliseconds(50),
+            )
 
-    def receive(self, timeout=None):
-        self._check_write_feedback()
+        def _convert_real_to_monotonic(self, value):
+            mono = time.monotonic()  # est_real is the best guess about real timestamp here
+            real = time.time()
+            est_real = self._mono_to_real_estimator.update(mono, real)
+            mono_to_real_offset = est_real - mono
+            return value - mono_to_real_offset
 
-        timeout = -1 if timeout is None else (timeout * 1000)
+        def _writer_thread_loop(self):
+            while not self._writer_thread_should_stop:
+                try:
+                    frame = self._write_queue.get(timeout=0.1)
+                except queue.Empty:
+                    continue
 
-        try:
-            msg = self._bus.recv(timeout=timeout)
-            if msg is not None:
-                ts_mono = time.monotonic()
-                ts_real = time.time()
+                try:
+                    while not self._writer_thread_should_stop:
+                        try:
+                            msg = can.Message(
+                                arbitration_id=frame.id,
+                                extended_id=frame.extended,
+                                dlc=len(frame.data),
+                                data=list(frame.data),
+                            )
+                            self._bus.send(msg)
+                            self._bus.flush_tx_buffer()
 
-                if ts_real and not ts_mono:
-                    ts_mono = self._convert_real_to_monotonic(ts_real)
+                            frame.ts_monotonic = time.monotonic()
+                            frame.ts_real = time.time()
+                            self._write_feedback_queue.put(frame)
+                        except OSError as ex:
+                            if ex.errno == errno.ENOBUFS:
+                                time.sleep(0.0002)
+                            else:
+                                raise
+                        else:
+                            break
+                except Exception as ex:
+                    self._write_feedback_queue.put(ex)
 
-                # timestamps are ugly still
-                frame = CANFrame(
-                    msg.arbitration_id,
-                    msg.data,
-                    True,
-                    ts_monotonic=ts_mono,
-                    ts_real=ts_real,
-                )
-                self._rx_hook(frame)
-                return frame
-        except Exception as ex:
-            logger.error("Receive exception", exc_info=True)
+        def _check_write_feedback(self):
+            try:
+                item = self._write_feedback_queue.get_nowait()
+            except queue.Empty:
+                return
 
-    def send(self, message_id, message, extended=False):
-        self._check_write_feedback()
-        try:
-            self._write_queue.put_nowait(CANFrame(message_id, message, extended))
-        except queue.Full:
-            raise TxQueueFullError()
+            if isinstance(item, Exception):
+                raise item
+
+            if isinstance(item, CANFrame):
+                self._tx_hook(item)
+            else:
+                raise DriverError("Unexpected item in write feedback queue: %r" % item)
+
+        def close(self):
+            self._writer_thread_should_stop = True
+            self._writer_thread.join()
+            self._bus.shutdown()
+
+        def receive(self, timeout=None):
+            self._check_write_feedback()
+
+            timeout = -1 if timeout is None else (timeout * 1000)
+
+            try:
+                msg = self._bus.recv(timeout=timeout)
+                if msg is not None:
+                    ts_mono = time.monotonic()
+                    ts_real = time.time()
+
+                    if ts_real and not ts_mono:
+                        ts_mono = self._convert_real_to_monotonic(ts_real)
+
+                    # timestamps are ugly still
+                    frame = CANFrame(
+                        msg.arbitration_id,
+                        msg.data,
+                        True,
+                        ts_monotonic=ts_mono,
+                        ts_real=ts_real,
+                    )
+                    self._rx_hook(frame)
+                    return frame
+            except Exception as ex:
+                logger.error("Receive exception", exc_info=True)
+
+        def send(self, message_id, message, extended=False):
+            self._check_write_feedback()
+            try:
+                self._write_queue.put_nowait(CANFrame(message_id, message, extended))
+            except queue.Full:
+                raise TxQueueFullError()


### PR DESCRIPTION
- Fixes the issue of not having python-can installed causing an error, even though users may want to use, e.g., SocketCAN instead.
- Allows passing CAN interface configuration information using the constructor instead of requiring the use of an INI file.
- Corrects other minor issues.