### PR TITLE
Allowing duplicate definitions when parsing dsdl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,10 @@ target/
 
 # IntelliJ
 .idea/
+
+# VS code
+.vscode
+
+# virtualenv
+.pyenv
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,12 @@
+environment:
+  matrix:
+    - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu
+      PYTHON: "3.7"
+
+stack: python %PYTHON%
+
+build: off
+branches:
+  except:
+    - gh-pages
+    - master

--- a/test/dsdl/__init__.py
+++ b/test/dsdl/__init__.py
@@ -1,0 +1,8 @@
+#
+# Copyright (C) 2014-2015  UAVCAN Development Team  <uavcan.org>
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# This software is distributed under the terms of the MIT License.
+#
+# Define dsdl folder as module so python unittest autodiscover will
+# work correctly

--- a/test/dsdl/fake_dsdl/ns0_base/ns0/20000.Type0.uavcan
+++ b/test/dsdl/fake_dsdl/ns0_base/ns0/20000.Type0.uavcan
@@ -1,0 +1,4 @@
+#
+# Base type for testing duplicate handling.
+#
+uint8 field0

--- a/test/dsdl/fake_dsdl/ns0_duplicated/ns0/20000.Type0.uavcan
+++ b/test/dsdl/fake_dsdl/ns0_duplicated/ns0/20000.Type0.uavcan
@@ -1,0 +1,5 @@
+#
+# Same definition as the base type to check that duplicates are
+# handled gracefully.
+#
+uint8 field0

--- a/test/dsdl/fake_dsdl/ns0_redefined/ns0/20000.Type0.uavcan
+++ b/test/dsdl/fake_dsdl/ns0_redefined/ns0/20000.Type0.uavcan
@@ -1,0 +1,4 @@
+#
+# Changing Type0's signature to check that this error is caught.
+#
+uint16 field0

--- a/test/dsdl/test_load_dsdl.py
+++ b/test/dsdl/test_load_dsdl.py
@@ -1,0 +1,51 @@
+#
+# Copyright (C) 2014-2015  UAVCAN Development Team  <uavcan.org>
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# This software is distributed under the terms of the MIT License.
+#
+# Author: Ben Dyer <ben_dyer@mac.com>
+#         Pavel Kirienko <pavel.kirienko@zubax.com>
+#
+
+import unittest
+import os
+from uavcan.dsdl import signature
+from uavcan.dsdl.common import DsdlException
+from uavcan import load_dsdl
+
+
+class TestLoadDsdl(unittest.TestCase):
+    '''
+    Unittests of the load_dsdl method.
+    '''
+
+    def test_reload(self):
+        '''
+        Test calling load_dsdl again (after it is called by the uavcan module)
+        '''
+        ns0_dir = '{}/fake_dsdl/ns0_base/ns0'.format(os.path.dirname(__file__))
+        load_dsdl(ns0_dir, exclude_dist=True)
+        import uavcan
+        test_type = uavcan.thirdparty.ns0.Type0()
+        self.assertEqual(test_type.field0, 0)
+
+    def test_reload_with_redefinition(self):
+        '''
+        Test calling load_dsdl with paths that contain two different types
+        with the same id.
+        '''
+        ns0_dir = '{}/fake_dsdl/ns0_base/ns0'.format(os.path.dirname(__file__))
+        ns0_dir_with_redefinition = '{}/fake_dsdl/ns0_redefined/ns0'.format(os.path.dirname(__file__))
+        try:
+            load_dsdl(ns0_dir, ns0_dir_with_redefinition, exclude_dist=True)
+        except DsdlException as e:
+            self.assertTrue(e.args[0].startswith("Redefinition of data type ID"))
+
+    def test_reload_with_duplication(self):
+        '''
+        Test calling load_dsdl with paths that contain the same type.
+        '''
+        ns0_dir = '{}/fake_dsdl/ns0_base/ns0'.format(os.path.dirname(__file__))
+        ns0_dir_with_redefinition = '{}/fake_dsdl/ns0_duplicated/ns0'.format(os.path.dirname(__file__))
+        load_dsdl(ns0_dir, ns0_dir_with_redefinition, exclude_dist=True)


### PR DESCRIPTION
duplicate == the same thing more than once. This is okay.
redefined == the same identifer used by incompatible definitions.
this is not okay.

In complex build systems duplicate dsdl files can get pulled in from
multiple dependencies and end up in long lists of paths that are
passed into the pyuavcan dsdl compiler. This change to the dsdl
parser allows this without throwing errors but enforces that the
duplicated definitions are compatible. This elminiates the need
for special case handling in build systems to try to find the duplicates
before invoking pyuavcan and adds a new check where such complex
systems will be notified when duplicated definitions get out of
sync.