### PR TITLE
Fix Collections Deprecation Warning

### DIFF
--- a/uavcan/transport.py
+++ b/uavcan/transport.py
@@ -14,7 +14,11 @@ import math
 import copy
 import struct
 import functools
-import collections.abc
+
+try:
+    import collections.abc  # Python 3
+except ImportError:
+    import collections  # Python 2
 
 import uavcan
 import uavcan.dsdl as dsdl

--- a/uavcan/transport.py
+++ b/uavcan/transport.py
@@ -17,8 +17,10 @@ import functools
 
 try:
     import collections.abc  # Python 3
+    MutableSequence = collections.abc.MutableSequence
 except ImportError:
     import collections  # Python 2
+    MutableSequence = collections.MutableSequence
 
 import uavcan
 import uavcan.dsdl as dsdl
@@ -329,7 +331,7 @@ class PrimitiveValue(BaseValue):
 
 
 # noinspection PyProtectedMember
-class ArrayValue(BaseValue, collections.abc.MutableSequence):
+class ArrayValue(BaseValue, MutableSequence):
     def __init__(self, _uavcan_type, *args, **kwargs):
         super(ArrayValue, self).__init__(_uavcan_type, *args, **kwargs)
 

--- a/uavcan/transport.py
+++ b/uavcan/transport.py
@@ -14,7 +14,7 @@ import math
 import copy
 import struct
 import functools
-import collections
+import collections.abc
 
 import uavcan
 import uavcan.dsdl as dsdl
@@ -325,7 +325,7 @@ class PrimitiveValue(BaseValue):
 
 
 # noinspection PyProtectedMember
-class ArrayValue(BaseValue, collections.MutableSequence):
+class ArrayValue(BaseValue, collections.abc.MutableSequence):
     def __init__(self, _uavcan_type, *args, **kwargs):
         super(ArrayValue, self).__init__(_uavcan_type, *args, **kwargs)
 


### PR DESCRIPTION
Minor change to get rid of a deprecation warning in 3.7

```
DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
```

Ref: https://docs.python.org/3/whatsnew/3.7.html#id3