### PR TITLE
Update pydsdl as requirement to 1.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@
 
 # Testing.
 pytest          ~= 4.6
-pytest-asyncio  >= 0.10, < 2.0
+pytest-asyncio  == 0.10
 coverage        ~= 5.0
 
 # Static analysis. PyLint is needed for the SonarQube scanner.

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,7 +60,7 @@ packages             = find:
 # Think thrice before adding anything here, please.
 # The preferred long-term plan is to avoid adding any new dependencies whatsoever for the project's lifetime.
 install_requires =
-    pydsdl  == 1.2.0 # TODO: issue #103 support new TaggedUnionType introduced in pydsdl 1.3
+    pydsdl  ~= 1.4
     numpy   ~= 1.16
     nunavut ~= 0.2
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,7 +62,7 @@ packages             = find:
 install_requires =
     pydsdl  ~= 1.4
     numpy   ~= 1.16
-    nunavut ~= 0.2
+    nunavut == 0.2.3
 
 [options.packages.find]
 # https://setuptools.readthedocs.io/en/latest/setuptools.html#find-namespace-packages


### PR DESCRIPTION
Since https://github.com/UAVCAN/pyuavcan/issues/103 is solved by https://github.com/UAVCAN/pydsdl/pull/39, ```pydsdl``` as requirement can be locked to ```1.4```.

Dependency nunavut also requires pydsdl 1.4, this PR solves the conflict.

This PR also fixes tests in pytest 5.4, closes https://github.com/UAVCAN/pyuavcan/issues/95