### PR TITLE
[legacy-v0] transport.py: Fix endianness of dynamic array lengths

### DIFF
--- a/uavcan/transport.py
+++ b/uavcan/transport.py
@@ -417,7 +417,7 @@ class ArrayValue(BaseValue, collections.MutableSequence):
         else:
             del self[:]
             count_width = array_len_bits_from_max_size(self._type.max_size)
-            count = int(stream[0:count_width], 2)
+            count = int(be_from_le_bits(stream[0:count_width], count_width), 2)
             stream = stream[count_width:]
             for _, last, i in enum_mark_last(range(count)):
                 new_item = self.__item_ctor()
@@ -439,7 +439,7 @@ class ArrayValue(BaseValue, collections.MutableSequence):
 
         else:
             count_width = array_len_bits_from_max_size(self._type.max_size)
-            count = format(len(self), '0{0:1d}b'.format(count_width))
+            count = le_from_be_bits(format(len(self), '0{0:1d}b'.format(count_width)), count_width)
             return count + ''.join(i._pack(tao and last) for _, last, i in enum_mark_last(self.__items))
 
     def from_bytes(self, value):


### PR DESCRIPTION
Dynamic array lengths are encoded as any other scalar, so when they're decoded/encoded we should
make sure they're read/written as little endian scalars. This change fixes the fact that converting binary
strings to/from ints assumes the string is in big endian representation, so arrays with max length over 256 would be incorrectly encoded.