### PR TITLE
Specify display of exception to InvalidMediaConfigurationError.

### DIFF
--- a/pyuavcan/transport/can/media/socketcan/_socketcan.py
+++ b/pyuavcan/transport/can/media/socketcan/_socketcan.py
@@ -14,7 +14,7 @@ import logging
 import threading
 import contextlib
 import pyuavcan.transport
-from pyuavcan.transport import Timestamp
+from pyuavcan.transport import Timestamp, InvalidMediaConfigurationError
 from pyuavcan.transport.can.media import Media, Envelope, FilterConfiguration, FrameFormat
 from pyuavcan.transport.can.media import DataFrame
 
@@ -131,6 +131,8 @@ class SocketCANMedia(Media):
                 )
             except asyncio.TimeoutError:
                 break
+            except OSError as e:
+                raise InvalidMediaConfigurationError()
             else:
                 num_sent += 1
         return num_sent


### PR DESCRIPTION
As mentioned in https://forum.uavcan.org/t/yakut-error-oserror-errno-22-invalid-argument/1434/2
it would be a significant usability boost if an error handler was added that caught OSError and raised the more sensible InvalidMediaConfigurationError.