### PR TITLE
transport: serial: catch malformed frames

### DIFF
--- a/pyuavcan/transport/serial/_frame.py
+++ b/pyuavcan/transport/serial/_frame.py
@@ -131,7 +131,10 @@ class SerialFrame(pyuavcan.transport.commons.high_overhead_transport.Frame):
             unescaped_image = cobs.decode(bytearray(image))  # TODO: PERFORMANCE WARNING: AVOID THE COPY
         except cobs.DecodeError:
             return None
-        return SerialFrame.parse_from_unescaped_image(memoryview(unescaped_image))
+        try:
+            SerialFrame.parse_from_unescaped_image(memoryview(unescaped_image))
+        except ValueError:
+            return None
 
     @staticmethod
     def parse_from_unescaped_image(header_payload_crc_image: memoryview) -> typing.Optional[SerialFrame]:


### PR DESCRIPTION
Pushed this real quick after reading #176 but wasn't sure how to test it @pavel-kirienko? What's the easiest way to induce the correct type of serial error?